### PR TITLE
[WIP] Add skel for collection release notes.

### DIFF
--- a/releasenotes/requirements.txt
+++ b/releasenotes/requirements.txt
@@ -1,0 +1,5 @@
+# The order of packages is significant, because pip processes them in the order
+# of appearance. Changing the order has an impact on the overall integration
+# process, which may cause wedges in the gate later.
+sphinx!=1.6.6,!=1.6.7,!=2.1.0,>=1.6.2;python_version>='3.4' # BSD
+reno>=2.5.0 # Apache-2.0

--- a/tox.ini
+++ b/tox.ini
@@ -30,3 +30,7 @@ ignore = E123,E125,E402,E501,E741,W503
 max-line-length = 160
 builtins = _
 exclude = .git,.tox,tests/unit/compat/
+
+[testenv:releasenotes]
+deps = -r{toxinidir}/releasenotes/requirements.txt
+commands = sphinx-build -a -W -E -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html


### PR DESCRIPTION
This commit adds the configuration and tox testenv for release notes on
ansible junos' collection.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>