### PR TITLE
Fix junos_lldp_interfaces xpath search

### DIFF
--- a/plugins/module_utils/network/junos/facts/lldp_interfaces/lldp_interfaces.py
+++ b/plugins/module_utils/network/junos/facts/lldp_interfaces/lldp_interfaces.py
@@ -68,10 +68,7 @@ class Lldp_interfacesFacts(object):
             config_filter = """
                 <configuration>
                     <protocols>
-                        <lldp>
-                            <interface>
-                            </interface>
-                        </lldp>
+                        <lldp/>
                     </protocols>
                 </configuration>
                 """


### PR DESCRIPTION
This PR fixes a search xpath in junos_lldp_interfaces which was
breaking junos_facts gathering when no lldp interface was present.