### PR TITLE
Update docs and add state for junos_static_routes

### DIFF
--- a/plugins/module_utils/network/junos/argspec/static_routes/static_routes.py
+++ b/plugins/module_utils/network/junos/argspec/static_routes/static_routes.py
@@ -74,7 +74,13 @@ class Static_routesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/config/static_routes/static_routes.py
+++ b/plugins/module_utils/network/junos/config/static_routes/static_routes.py
@@ -71,10 +71,14 @@ class Static_routes(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_static_routes_facts = self.get_static_routes_facts()
         config_xmls = self.set_config(existing_static_routes_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_static_routes_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/modules/junos_static_routes.py
+++ b/plugins/modules/junos_static_routes.py
@@ -29,14 +29,10 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
 DOCUMENTATION = """module: junos_static_routes
-short_description: Manage static routes on Juniper JUNOS devices
+short_description: Static routes Junos resource module
 description: This module provides declarative management of static routes on Juniper
   JUNOS devices
 author: Daniel Mellado (@dmellado)
@@ -104,6 +100,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 """
 


### PR DESCRIPTION
This commit adds gathered state for junos_static_routes and updates the
documentation to the new resource modules versioning for collections.