### PR TITLE
Update docs and add state for junos_l3_interfaces

### DIFF
--- a/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/l3_interfaces/l3_interfaces.py
@@ -38,7 +38,13 @@ class L3_interfacesArgs(object):  # pylint: disable=R0903
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
+++ b/plugins/module_utils/network/junos/config/l3_interfaces/l3_interfaces.py
@@ -71,11 +71,15 @@ class L3_interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_interfaces_facts = self.get_l3_interfaces_facts()
-
         config_xmls = self.set_config(existing_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_interfaces_facts
+
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):
                 diff = load_config(self._module, config_xml, warnings)

--- a/plugins/modules/junos_l3_interfaces.py
+++ b/plugins/modules/junos_l3_interfaces.py
@@ -30,14 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_l3_interfaces
-short_description: Manage Layer 3 interface on Juniper JUNOS devices
+DOCUMENTATION = """
+---
+module: junos_l3_interfaces
+version_added: "1.0.0"
+short_description: Junos L3 Interfaces resource module
 description: This module provides declarative management of a Layer 3 interface on
   Juniper JUNOS devices
 author: Daniel Mellado (@dmellado)
@@ -98,6 +97,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 """
 EXAMPLES = """


### PR DESCRIPTION
This commit adds gathered state for junos_l3_interfaces and updates the
documentation to the new resource modules versioning for collections.