### PR TITLE
Update docs and add state for junos_l2_interfaces

### DIFF
--- a/plugins/module_utils/network/junos/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/l2_interfaces/l2_interfaces.py
@@ -59,7 +59,13 @@ class L2_interfacesArgs(object):
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
@@ -76,10 +76,14 @@ class L2_interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
 
         existing_l2_interfaces_facts = self.get_l2_interfaces_facts()
-
         config_xmls = self.set_config(existing_l2_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_l2_interfaces_facts
+
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):
                 diff = load_config(self._module, config_xml, [])

--- a/plugins/modules/junos_l2_interfaces.py
+++ b/plugins/modules/junos_l2_interfaces.py
@@ -30,14 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_l2_interfaces
-short_description: Manage Layer-2 interface on Juniper JUNOS devices
+DOCUMENTATION = """
+---
+module: junos_l2_interfaces
+version_added: "1.0.0"
+short_description: JUNOS L2 interfaces resource module
 description: This module provides declarative management of a Layer-2 interface on
   Juniper JUNOS devices.
 author: Ganesh Nalawade (@ganeshrn)
@@ -92,6 +91,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
     description:
     - The state of the configuration after module completion


### PR DESCRIPTION
This commit adds gathered state for junos_l2_interfaces and updates the
documentation to the new resource modules versioning for collections.