### PR TITLE
Update docs and add state for junos_lag_interfaces

### DIFF
--- a/plugins/module_utils/network/junos/argspec/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/lag_interfaces/lag_interfaces.py
@@ -56,7 +56,13 @@ class Lag_interfacesArgs(object):
             "type": "list",
         },
         "state": {
-            "choices": ["merged", "replaced", "overridden", "deleted"],
+            "choices": [
+                "merged",
+                "replaced",
+                "overridden",
+                "deleted",
+                "gathered",
+            ],
             "default": "merged",
             "type": "str",
         },

--- a/plugins/module_utils/network/junos/config/lag_interfaces/lag_interfaces.py
+++ b/plugins/module_utils/network/junos/config/lag_interfaces/lag_interfaces.py
@@ -73,10 +73,14 @@ class Lag_interfaces(ConfigBase):
         :returns: The result from module execution
         """
         result = {"changed": False}
+        state = self._module.params["state"]
         warnings = list()
 
         existing_lag_interfaces_facts = self.get_lag_interfaces_facts()
         config_xmls = self.set_config(existing_lag_interfaces_facts)
+
+        if state == "gathered":
+            result["gathered"] = existing_lag_interfaces_facts
 
         with locked_config(self._module):
             for config_xml in to_list(config_xmls):

--- a/plugins/modules/junos_lag_interfaces.py
+++ b/plugins/modules/junos_lag_interfaces.py
@@ -30,14 +30,13 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    "metadata_version": "1.1",
-    "status": ["preview"],
-    "supported_by": "network",
-}
+ANSIBLE_METADATA = {"metadata_version": "1.1", "supported_by": "network"}
 
-DOCUMENTATION = """module: junos_lag_interfaces
-short_description: Manage Link Aggregation on Juniper JUNOS devices.
+DOCUMENTATION = """
+---
+module: junos_lag_interfaces
+version_added: "1.0.0"
+short_description: Link Aggregation Juniper JUNOS resource module
 description: This module manages properties of Link Aggregation Group on Juniper JUNOS
   devices.
 author: Ganesh Nalawade (@ganeshrn)
@@ -92,6 +91,7 @@ options:
     - replaced
     - overridden
     - deleted
+    - gathered
     default: merged
 requirements:
 - ncclient (>=v0.6.4)


### PR DESCRIPTION
This commit adds gathered state for junos_lag_interfaces and updates the
documentation to the new resource modules versioning for collections.