### PR TITLE
Set ignore_basepython_conflict to true

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-minversion = 1.4.2
+minversion = 3.2.0
 envlist = linters
 skipsdist = True
+ignore_basepython_conflict = True
 
 [testenv]
 basepython = python3
@@ -10,12 +11,10 @@ deps = -r{toxinidir}/requirements.txt
 commands = find {toxinidir} -type f -name "*.py[c|o]" -delete
 
 [testenv:black]
-install_command = pip install {opts} {packages}
 commands =
   black -v -l79 {toxinidir}
 
 [testenv:linters]
-install_command = pip install {opts} {packages}
 commands =
   black -v -l79 --check {toxinidir}
   flake8 {posargs}


### PR DESCRIPTION
Adding a basepython setting on tox makes it complains about a basepython
mismatch when the installed python version and the environment aren't
the same. Setting ignore_basepython_conflict avoids this message and
enforces the correct python version to be used.

This also needs a bump in tox version, which also comes with a feature
which lets us remove the default install setting.

See also [1]

[1] http://lists.openstack.org/pipermail/openstack-discuss/2020-May/014809.html