### PR TITLE
Explicitly rename junos_ospf to junos_ospfv2

### DIFF
--- a/docs/junipernetworks.junos.junos_ospfv2.rst
+++ b/docs/junipernetworks.junos.junos_ospfv2.rst
@@ -1,12 +1,12 @@
 
-.. _junipernetworks.junos.junos_ospf_:
+.. _junipernetworks.junos.junos_ospfv2_:
 
 
 *****
-junipernetworks.junos.junos_ospf
+junipernetworks.junos.junos_ospfv2
 *****
 
-**OSPF resource module**
+**OSPFv2 resource module**
 
 
 Version added: 1.0.0
@@ -174,7 +174,7 @@ Parameters
                                             <div>Type of authentication to use.</div>
                                                         </td>
             </tr>
-                    
+
                                                 <tr>
                                                     <td class="elbow-placeholder"></td>
                                     <td class="elbow-placeholder"></td>
@@ -240,7 +240,7 @@ Parameters
                                             <div>None</div>
                                                         </td>
             </tr>
-                    
+
                                                 <tr>
                                                     <td class="elbow-placeholder"></td>
                                     <td class="elbow-placeholder"></td>
@@ -472,8 +472,8 @@ Parameters
                                             <div>Transit delay (seconds).</div>
                                                         </td>
             </tr>
-                    
-                                    
+
+
                                                 <tr>
                                                     <td class="elbow-placeholder"></td>
                                     <td class="elbow-placeholder"></td>
@@ -537,8 +537,8 @@ Parameters
                                             <div>Configure the area as a stub.</div>
                                                         </td>
             </tr>
-                    
-                                    
+
+
                                                 <tr>
                                                     <td class="elbow-placeholder"></td>
                                                 <td colspan="4">
@@ -593,7 +593,7 @@ Parameters
                                             <div>Time after which overload mode is reset (seconds).</div>
                                                         </td>
             </tr>
-                    
+
                                                 <tr>
                                                     <td class="elbow-placeholder"></td>
                                                 <td colspan="4">
@@ -767,8 +767,8 @@ Parameters
                                             <div>Number of maximum rapid SPF runs before holddown (seconds).</div>
                                                         </td>
             </tr>
-                    
-                                    
+
+
                                                 <tr>
                                                                 <td colspan="5">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
@@ -812,7 +812,7 @@ Examples
 
 .. code-block:: yaml+jinja
 
-    
+
     # Using merged
     #
     # Before state
@@ -821,7 +821,7 @@ Examples
     # admin# show protocols ospf
 
     - name: Merge Junos OSPF config
-      junipernetworks.junos.junos_ospf:
+      junipernetworks.junos.junos_ospfv2:
         config:
         - router_id: 10.200.16.75
           reference_bandwidth: 10g

--- a/plugins/module_utils/network/junos/argspec/ospf/ospf.py
+++ b/plugins/module_utils/network/junos/argspec/ospf/ospf.py
@@ -15,12 +15,12 @@
 
 
 """
-The arg spec for the junos_ospf module
+The arg spec for the junos_ospfv2 module
 """
 
 
 class OspfArgs(object):  # pylint: disable=R0903
-    """The arg spec for the junos_ospf module
+    """The arg spec for the junos_ospfv2 module
     """
 
     def __init__(self, **kwargs):

--- a/plugins/module_utils/network/junos/config/ospf/ospf.py
+++ b/plugins/module_utils/network/junos/config/ospf/ospf.py
@@ -15,7 +15,7 @@
 
 
 """
-The junos_ospf class
+The junos_ospfv2 class
 It is in this file where the current configuration (as dict)
 is compared to the provided configuration (as dict) and the command set
 necessary to bring the current configuration to it's desired end-state is
@@ -47,7 +47,7 @@ from ansible_collections.ansible.netcommon.plugins.module_utils.network.common.n
 
 class Ospf(ConfigBase):
     """
-    The junos_ospf class
+    The junos_ospfv2 class
     """
 
     gather_subset = ["!all", "!min"]

--- a/plugins/module_utils/network/junos/facts/ospf/ospf.py
+++ b/plugins/module_utils/network/junos/facts/ospf/ospf.py
@@ -16,7 +16,7 @@
 
 
 """
-The junos ospf fact class
+The junos_ospfv2 fact class
 It is in this file the configuration is collected from the device
 for a given resource, parsed, and the facts tree is populated
 based on the configuration.

--- a/plugins/modules/junos_ospfv2.py
+++ b/plugins/modules/junos_ospfv2.py
@@ -23,7 +23,7 @@
 #############################################
 
 """
-The module file for junos_ospf
+The module file for junos_ospfv2
 """
 
 from __future__ import absolute_import, division, print_function
@@ -32,8 +32,8 @@ __metaclass__ = type
 
 
 DOCUMENTATION = """
-module: junos_ospf
-short_description: OSPF resource module
+module: junos_ospfv2
+short_description: OSPFv2 resource module
 description:
 - This module manages global OSPFv2 configuration on devices running Juniper JUNOS.
 version_added: 1.0.0
@@ -47,18 +47,18 @@ notes:
 - Tested against JunOS v18.4R1
 options:
   config:
-    description: A list of OSPF process configuration.
+    description: A list of OSPFv2 process configuration.
     type: list
     elements: dict
     suboptions:
       router_id:
         description:
-        - The OSPF router id.
+        - The OSPFv2 router id.
         type: str
         required: true
       areas:
         description:
-        - A list of OSPF areas' configuration.
+        - A list of OSPFv2 areas' configuration.
         type: list
         elements: dict
         suboptions:
@@ -217,8 +217,8 @@ EXAMPLES = """
 #
 # admin# show protocols ospf
 
-- name: Merge Junos OSPF config
-  junipernetworks.junos.junos_ospf:
+- name: Merge Junos OSPFv2 config
+  junipernetworks.junos.junos_ospfv2:
     config:
     - router_id: 10.200.16.75
       reference_bandwidth: 10g

--- a/tests/integration/targets/junos_ospf/tests/netconf/_initial_config.yaml
+++ b/tests/integration/targets/junos_ospf/tests/netconf/_initial_config.yaml
@@ -1,9 +1,9 @@
 ---
 - debug:
-    msg: "START junos_ospf initial config on connection={{ ansible_connection }}"
+    msg: "START junos_ospfv2 initial config on connection={{ ansible_connection }}"
 
 - name: Set initial configuration for ospf
-  junos_ospf:
+  junos_ospfv2:
     config:
       - router_id: 10.200.16.75
         areas:
@@ -15,4 +15,4 @@
               - name: ge-2/2/0.0
 
 - debug:
-    msg: "END junos_ospf initial config on connection={{ ansible_connection }}"
+    msg: "END junos_ospfv2 initial config on connection={{ ansible_connection }}"

--- a/tests/integration/targets/junos_ospf/tests/netconf/_reset_config.yaml
+++ b/tests/integration/targets/junos_ospf/tests/netconf/_reset_config.yaml
@@ -1,6 +1,6 @@
 ---
 - debug:
-    msg: "START junos_ospf reset config on connection={{ ansible_connection }}"
+    msg: "START junos_ospfv2 reset config on connection={{ ansible_connection }}"
 
 - name: Reset configuration for ospf and routing-options
   junos_config:
@@ -8,4 +8,4 @@
       - delete protocols ospf
       - delete routing-options
 - debug:
-    msg: "END junos_ospf reset config on connection={{ ansible_connection }}"
+    msg: "END junos_ospfv2 reset config on connection={{ ansible_connection }}"

--- a/tests/integration/targets/junos_ospf/tests/netconf/deleted.yaml
+++ b/tests/integration/targets/junos_ospf/tests/netconf/deleted.yaml
@@ -1,6 +1,6 @@
 ---
 - debug:
-    msg: "START junos_ospf deleted integration tests on connection={{ ansible_connection }}"
+    msg: "START junos_ospfv2 deleted integration tests on connection={{ ansible_connection }}"
 
 - block:
     - include_tasks: _reset_config.yaml
@@ -15,7 +15,7 @@
                   - name: ge-2/2/0.0
 
     - name: Delete an area
-      junos_ospf:
+      junos_ospfv2:
         config:
           - router_id: 10.200.16.75
             areas:
@@ -41,7 +41,7 @@
         config: []
 
     - name: Delete all ospf config from the device
-      junos_ospf:
+      junos_ospfv2:
         state: deleted
       register: result
 
@@ -53,4 +53,4 @@
     - include_tasks: _reset_config.yaml
 
 - debug:
-    msg: "END junos_ospf deleted integration tests on connection={{ ansible_connection }}"
+    msg: "END junos_ospfv2 deleted integration tests on connection={{ ansible_connection }}"

--- a/tests/integration/targets/junos_ospf/tests/netconf/merged.yaml
+++ b/tests/integration/targets/junos_ospf/tests/netconf/merged.yaml
@@ -1,6 +1,6 @@
 ---
 - debug:
-    msg: "START junos_ospf merged integration tests on connection={{ ansible_connection }}"
+    msg: "START junos_ospfv2 merged integration tests on connection={{ ansible_connection }}"
 
 - block:
     - include_tasks: _reset_config.yaml
@@ -19,7 +19,7 @@
             router_id: 10.200.16.75
 
     - name: Merge the provided configuration with the exisiting running configuration
-      junos_ospf: &merged
+      junos_ospfv2: &merged
         config:
           - router_id: 10.200.16.75
             areas:
@@ -41,7 +41,7 @@
           - "{{ config|symmetric_difference(result.after) == [] }}"
 
     - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
-      junos_ospf: *merged
+      junos_ospfv2: *merged
       register: result
 
     - name: Assert that the previous task was idempotent
@@ -54,4 +54,4 @@
     - include_tasks: _reset_config.yaml
 
 - debug:
-    msg: "END junos_ospf merged integration tests on connection={{ ansible_connection }}"
+    msg: "END junos_ospfv2 merged integration tests on connection={{ ansible_connection }}"

--- a/tests/integration/targets/junos_ospf/tests/netconf/overridden.yaml
+++ b/tests/integration/targets/junos_ospf/tests/netconf/overridden.yaml
@@ -1,6 +1,6 @@
 ---
 - debug:
-    msg: "START junos_ospf overridden integration tests on connection={{ ansible_connection }}"
+    msg: "START junos_ospfv2 overridden integration tests on connection={{ ansible_connection }}"
 
 - block:
     - include_tasks: _reset_config.yaml
@@ -26,7 +26,7 @@
                   - name: ge-2/2/0.0
 
     - name: Override Junos OSPF config
-      junos_ospf:
+      junos_ospfv2:
         config:
           - router_id: 10.200.16.75
             areas:
@@ -61,4 +61,4 @@
     - include_tasks: _reset_config.yaml
 
 - debug:
-    msg: "END junos_ospf overridden integration tests on connection={{ ansible_connection }}"
+    msg: "END junos_ospfv2 overridden integration tests on connection={{ ansible_connection }}"

--- a/tests/integration/targets/junos_ospf/tests/netconf/replaced.yaml
+++ b/tests/integration/targets/junos_ospf/tests/netconf/replaced.yaml
@@ -1,6 +1,6 @@
 ---
 - debug:
-    msg: "START junos_ospf replaced integration tests on connection={{ ansible_connection }}"
+    msg: "START junos_ospfv2 replaced integration tests on connection={{ ansible_connection }}"
 
 - block:
     - include_tasks: _reset_config.yaml
@@ -18,7 +18,7 @@
                   - name: so-0/0/0.0
 
     - name: Replace configuration
-      junos_ospf:
+      junos_ospfv2:
         config:
           - router_id: 10.200.16.75
             areas:
@@ -38,4 +38,4 @@
     - include_tasks: _reset_config.yaml
 
 - debug:
-    msg: "END junos_ospf replaced integration tests on connection={{ ansible_connection }}"
+    msg: "END junos_ospfv2 replaced integration tests on connection={{ ansible_connection }}"


### PR DESCRIPTION
This PR renames ospf to ospfv2 in order to be explicitly clear about
the protocol used.