### PR TITLE
Add dummy version to galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,3 +9,4 @@ namespace: junipernetworks
 readme: README.md
 repository: https://github.com/ansible-collections/junipernetworks.junos
 tags: [juniper, junipernetworks, junos, networking, security, netconf]
+version: null


### PR DESCRIPTION
This PR adds the version keyword to galaxy.yml in order to galaxy not
complainging about missing keyword when installing collections.

Depends-On: https://github.com/ansible-collections/junipernetworks.junos/pull/52
Signed-off-by: Daniel Mellado <dmellado@redhat.com>