### PR TITLE
Handle src & backup properly when module alias is used

### DIFF
--- a/changelogs/fragments/fix_config_module_src_backup.yaml
+++ b/changelogs/fragments/fix_config_module_src_backup.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Make `src`, `backup` and `backup_options` in junos_config work when module alias is used (https://github.com/ansible-collections/junipernetworks.junos/pull/83).

--- a/plugins/action/junos.py
+++ b/plugins/action/junos.py
@@ -44,7 +44,9 @@ class ActionModule(ActionNetworkModule):
         del tmp  # tmp no longer has any effect
 
         module_name = self._task.action.split(".")[-1]
-        self._config_module = True if module_name == "junos_config" else False
+        self._config_module = (
+            True if module_name in ["junos_config", "config"] else False
+        )
         persistent_connection = self._play_context.connection.split(".")[-1]
         warnings = []
 

--- a/tests/integration/targets/junos_config/tasks/main.yaml
+++ b/tests/integration/targets/junos_config/tasks/main.yaml
@@ -4,3 +4,6 @@
 - include: cli_config.yaml
   tags:
     - network_cli
+
+- include: redirection.yaml
+  when: ansible_version.full is version('2.10.0', '>=')

--- a/tests/integration/targets/junos_config/tasks/redirection.yaml
+++ b/tests/integration/targets/junos_config/tasks/redirection.yaml
@@ -1,0 +1,16 @@
+---
+- name: collect redirection test cases
+  find:
+    paths: '{{ role_path }}/tests/redirection/'
+    patterns: '{{ testcase }}.yaml'
+  connection: local
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case (connection=ansible.netcommon.netconf)
+  include: '{{ test_case_to_run }} ansible_connection=ansible.netcommon.netconf'
+  with_items: '{{ test_items }}'
+  loop_control:
+    loop_var: test_case_to_run

--- a/tests/integration/targets/junos_config/tests/redirection/shortname.yaml
+++ b/tests/integration/targets/junos_config/tests/redirection/shortname.yaml
@@ -1,0 +1,51 @@
+---
+- debug: msg="START redirection/netconf/shortname.yaml on connection={{ ansible_connection }}"
+
+- name: setup
+  junipernetworks.junos.config:
+    lines:
+      - delete interfaces lo0
+    provider: '{{ netconf }}'
+
+- name: Use src with module alias
+  register: result
+  junipernetworks.junos.config:
+    src: basic/config.j2
+    provider: '{{ netconf }}'
+
+- assert:
+    that:
+      # make sure that the template content was read and not the path
+      - result.changed == true
+
+- name: teardown
+  register: result
+  junipernetworks.junos.config:
+    lines:
+      - delete interfaces lo0
+    provider: '{{ netconf }}'
+
+- name: use module alias to take configuration backup
+  register: result
+  junipernetworks.junos.config:
+    backup: true
+    backup_options:
+      filename: backup_with_alias.cfg
+      dir_path: '{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}'
+    provider: '{{ netconf }}'
+
+- assert:
+    that:
+      - result.changed == true
+
+- name: check if the backup file-4 exist
+  find:
+    paths: '{{ role_path }}/backup_test_dir/{{ inventory_hostname_short }}/backup_with_alias.cfg'
+  register: backup_file
+  connection: local
+
+- assert:
+    that:
+      - backup_file.files is defined
+
+- debug: msg="END redirection/netconf/shortname.yaml on connection={{ ansible_connection }}"


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Module name will not always be prefixed with {{ network_os }}_.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
action/junos.py
junos_config.py
