### PR TITLE
[Junos] gathered opr and empty config trace back fix for junos_l2_interfaces

### DIFF
--- a/changelogs/fragments/91_gathered_opr_fix_junos_l2interfaces.yaml
+++ b/changelogs/fragments/91_gathered_opr_fix_junos_l2interfaces.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - set_config called only when state is not gathered so that gathered opeartion works fine for l2_interfaces resource module (https://github.com/ansible-collections/junipernetworks.junos/issues/91).

--- a/plugins/module_utils/network/junos/argspec/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/l2_interfaces/l2_interfaces.py
@@ -58,6 +58,7 @@ class L2_interfacesArgs(object):
             },
             "type": "list",
         },
+        "running_config": {"type": "str"},
         "state": {
             "choices": [
                 "merged",
@@ -65,6 +66,8 @@ class L2_interfacesArgs(object):
                 "overridden",
                 "deleted",
                 "gathered",
+                "rendered",
+                "parsed",
             ],
             "default": "merged",
             "type": "str",

--- a/plugins/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
@@ -79,33 +79,34 @@ class L2_interfaces(ConfigBase):
         state = self._module.params["state"]
 
         existing_l2_interfaces_facts = self.get_l2_interfaces_facts()
-        config_xmls = self.set_config(existing_l2_interfaces_facts)
 
+        existing_l2_interfaces_facts
         if state == "gathered":
             result["gathered"] = existing_l2_interfaces_facts
+        else:
+            config_xmls = self.set_config(existing_l2_interfaces_facts)
+            with locked_config(self._module):
+                for config_xml in to_list(config_xmls):
+                    diff = load_config(self._module, config_xml, [])
 
-        with locked_config(self._module):
-            for config_xml in to_list(config_xmls):
-                diff = load_config(self._module, config_xml, [])
+                commit = not self._module.check_mode
+                if diff:
+                    if commit:
+                        commit_configuration(self._module)
+                    else:
+                        discard_changes(self._module)
+                    result["changed"] = True
 
-            commit = not self._module.check_mode
-            if diff:
-                if commit:
-                    commit_configuration(self._module)
-                else:
-                    discard_changes(self._module)
-                result["changed"] = True
+                    if self._module._diff:
+                        result["diff"] = {"prepared": diff}
 
-                if self._module._diff:
-                    result["diff"] = {"prepared": diff}
+            result["commands"] = config_xmls
 
-        result["commands"] = config_xmls
+            changed_l2_interfaces_facts = self.get_l2_interfaces_facts()
 
-        changed_l2_interfaces_facts = self.get_l2_interfaces_facts()
-
-        result["before"] = existing_l2_interfaces_facts
-        if result["changed"]:
-            result["after"] = changed_l2_interfaces_facts
+            result["before"] = existing_l2_interfaces_facts
+            if result["changed"]:
+                result["after"] = changed_l2_interfaces_facts
 
         return result
 
@@ -133,6 +134,15 @@ class L2_interfaces(ConfigBase):
         """
         root = build_root_xml_node("interfaces")
         state = self._module.params["state"]
+        if (
+            state in ("merged", "replaced", "overridden")
+            and not want
+        ):
+            self._module.fail_json(
+                msg="value of config parameter must not be empty for state {0}".format(
+                    state
+                )
+            )
         if state == "overridden":
             config_xmls = self._state_overridden(want, have)
         elif state == "deleted":

--- a/plugins/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
+++ b/plugins/module_utils/network/junos/config/l2_interfaces/l2_interfaces.py
@@ -152,7 +152,10 @@ class L2_interfaces(ConfigBase):
         """
         root = build_root_xml_node("interfaces")
         state = self._module.params["state"]
-        if state in ("merged", "replaced", "overridden") and not want:
+        if (
+            state in ("merged", "replaced", "overridden", "rendered")
+            and not want
+        ):
             self._module.fail_json(
                 msg="value of config parameter must not be empty for state {0}".format(
                     state

--- a/plugins/modules/junos_l2_interfaces.py
+++ b/plugins/modules/junos_l2_interfaces.py
@@ -84,6 +84,15 @@ options:
           is under C(interface-mode) the value is True else if the l2 configuration
           is under C(port-mode) value is False
         type: bool
+  running_config:
+    description:
+    - This option is used only with state I(parsed).
+    - The value of this option should be the output received from the Junos device
+      by executing the command B(show interfaces).
+    - The state I(parsed) reads the configuration from C(running_config) option and
+      transforms it into Ansible structured data as per the resource module's argspec
+      and the value is then returned in the I(parsed) key within the result.
+    type: str
   state:
     choices:
     - merged
@@ -91,6 +100,8 @@ options:
     - overridden
     - deleted
     - gathered
+    - parsed
+    - rendered
     default: merged
     description:
     - The state of the configuration after module completion
@@ -478,6 +489,118 @@ EXAMPLES = """
 #         }
 #     }
 # }
+# Using parsed
+# parsed.cfg
+# ------------
+#
+# <?xml version="1.0" encoding="UTF-8"?>
+# <rpc-reply message-id="urn:uuid:0cadb4e8-5bba-47f4-986e-72906227007f">
+#     <configuration changed-seconds="1590139550" changed-localtime="2020-05-22 09:25:50 UTC">
+#         <interfaces>
+#             <interface>
+#                 <name>ge-0/0/1</name>
+#                 <description>Configured by Ansible</description>
+#                 <disable/>
+#                 <speed>100m</speed>
+#                 <mtu>1024</mtu>
+#                 <hold-time>
+#                     <up>2000</up>
+#                     <down>2200</down>
+#                 </hold-time>
+#                 <link-mode>full-duplex</link-mode>
+#                 <unit>
+#                     <name>0</name>
+#                     <family>
+#                         <ethernet-switching>
+#                             <interface-mode>access</interface-mode>
+#                             <vlan>
+#                                 <members>vlan100</members>
+#                             </vlan>
+#                         </ethernet-switching>
+#                     </family>
+#                 </unit>
+#             </interface>
+#         </interfaces>
+#     </configuration>
+# </rpc-reply>
+# - name: Convert interfaces config to argspec without connecting to the appliance
+#   junipernetworks.junos.junos_l2_interfaces:
+#     running_config: "{{ lookup('file', './parsed.cfg') }}"
+#     state: parsed
+# Task Output (redacted)
+# -----------------------
+# "parsed": [
+#         {
+#             "access": {
+#                 "vlan": "vlan100"
+#             },
+#             "enhanced_layer": true,
+#             "name": "ge-0/0/1",
+#             "unit": 0
+#         },
+#         {
+#             "enhanced_layer": true,
+#             "name": "ge-0/0/2",
+#             "trunk": {
+#                 "allowed_vlans": [
+#                     "vlan200",
+#                     "vlan300"
+#                 ],
+#                 "native_vlan": "400"
+#             },
+#             "unit": 0
+#         }
+#     ]
+#
+# Using rendered
+- name: Render platform specific xml from task input using rendered state
+  junipernetworks.junos.junos_l2_interfaces:
+    config:
+      - name: ge-0/0/1
+        access:
+          vlan: vlan100
+      - name: ge-0/0/2
+        trunk:
+          allowed_vlans:
+            - vlan200
+            - vlan300
+          native_vlan: '400'
+    state: rendered
+# Task Output (redacted)
+# -----------------------
+# "rendered": "<nc:interfaces
+#     xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">
+#     <nc:interface>
+#         <nc:name>ge-0/0/1</nc:name>
+#         <nc:unit>
+#             <nc:name>0</nc:name>
+#             <nc:family>
+#                 <nc:ethernet-switching>
+#                     <nc:interface-mode>access</nc:interface-mode>
+#                     <nc:vlan>
+#                         <nc:members>vlan100</nc:members>
+#                     </nc:vlan>
+#                 </nc:ethernet-switching>
+#             </nc:family>
+#         </nc:unit>
+#     </nc:interface>
+#     <nc:interface>
+#         <nc:name>ge-0/0/2</nc:name>
+#         <nc:unit>
+#             <nc:name>0</nc:name>
+#             <nc:family>
+#                 <nc:ethernet-switching>
+#                     <nc:interface-mode>trunk</nc:interface-mode>
+#                     <nc:vlan>
+#                         <nc:members>vlan200</nc:members>
+#                         <nc:members>vlan300</nc:members>
+#                     </nc:vlan>
+#                 </nc:ethernet-switching>
+#             </nc:family>
+#         </nc:unit>
+#         <nc:native-vlan-id>400</nc:native-vlan-id>
+#     </nc:interface>
+# </nc:interfaces>"
 
 """
 RETURN = """
@@ -499,7 +622,39 @@ commands:
   description: The set of commands pushed to the remote device.
   returned: always
   type: list
-  sample: ['command 1', 'command 2', 'command 3']
+  sample: ['<nc:interfaces
+                                   xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">
+                                   <nc:interface>
+                                       <nc:name>ge-0/0/1</nc:name>
+                                       <nc:unit>
+                                           <nc:name>0</nc:name>
+                                           <nc:family>
+                                               <nc:ethernet-switching>
+                                                   <nc:interface-mode>access</nc:interface-mode>
+                                                   <nc:vlan>
+                                                       <nc:members>vlan100</nc:members>
+                                                   </nc:vlan>
+                                               </nc:ethernet-switching>
+                                           </nc:family>
+                                       </nc:unit>
+                                   </nc:interface>
+                                   <nc:interface>
+                                       <nc:name>ge-0/0/2</nc:name>
+                                       <nc:unit>
+                                           <nc:name>0</nc:name>
+                                           <nc:family>
+                                               <nc:ethernet-switching>
+                                                   <nc:interface-mode>trunk</nc:interface-mode>
+                                                   <nc:vlan>
+                                                       <nc:members>vlan200</nc:members>
+                                                       <nc:members>vlan300</nc:members>
+                                                   </nc:vlan>
+                                               </nc:ethernet-switching>
+                                           </nc:family>
+                                       </nc:unit>
+                                       <nc:native-vlan-id>400</nc:native-vlan-id>
+                                   </nc:interface>
+                               </nc:interfaces>', 'xml 2', 'xml 3']
 """
 
 
@@ -521,7 +676,9 @@ def main():
     required_if = [
         ("state", "merged", ("config",)),
         ("state", "replaced", ("config",)),
+        ("state", "rendered", ("config",)),
         ("state", "overridden", ("config",)),
+        ("state", "parsed", ("running_config",)),
     ]
 
     module = AnsibleModule(

--- a/plugins/modules/junos_l2_interfaces.py
+++ b/plugins/modules/junos_l2_interfaces.py
@@ -353,7 +353,131 @@ EXAMPLES = """
 #        }
 #    }
 # }
-
+# Using gathered
+# Before state:
+# ------------
+#
+# user@junos01# show interfaces
+# ge-0/0/1 {
+#     description "Configured by Ansible";
+#     disable;
+#     speed 100m;
+#     mtu 1024;
+#     hold-time up 2000 down 2200;
+#     link-mode full-duplex;
+#     unit 0 {
+#         family ethernet-switching {
+#             interface-mode access;
+#             vlan {
+#                 members vlan100;
+#             }
+#         }
+#     }
+# }
+# ge-0/0/2 {
+#     description "Configured by Ansible";
+#     native-vlan-id 400;
+#     speed 10m;
+#     mtu 2048;
+#     hold-time up 3000 down 3200;
+#     unit 0 {
+#         family ethernet-switching {
+#             interface-mode trunk;
+#             vlan {
+#                 members [ vlan200 vlan300 ];
+#             }
+#         }
+#     }
+# }
+# em1 {
+#     description TEST;
+# }
+# fxp0 {
+#     description ANSIBLE;
+#     speed 1g;
+#     link-mode automatic;
+#     unit 0 {
+#         family inet {
+#             address 10.8.38.38/24;
+#         }
+#     }
+# }
+- name: Gather junos layer 2 interfaces as in given arguments
+  junipernetworks.junos.junos_l2_interfaces:
+    state: gathered
+# Task Output (redacted)
+# -----------------------
+#
+# "gathered": [
+#         {
+#             "access": {
+#                 "vlan": "vlan100"
+#             },
+#             "enhanced_layer": true,
+#             "name": "ge-0/0/1",
+#             "unit": 0
+#         },
+#         {
+#             "enhanced_layer": true,
+#             "name": "ge-0/0/2",
+#             "trunk": {
+#                 "allowed_vlans": [
+#                     "vlan200",
+#                     "vlan300"
+#                 ],
+#                 "native_vlan": "400"
+#             },
+#             "unit": 0
+#         }
+#     ]
+# After state:
+# ------------
+#
+# user@junos01# show interfaces
+# ge-0/0/1 {
+#     description "Configured by Ansible";
+#     disable;
+#     speed 100m;
+#     mtu 1024;
+#     hold-time up 2000 down 2200;
+#     link-mode full-duplex;
+#     unit 0 {
+#         family ethernet-switching {
+#             interface-mode access;
+#             vlan {
+#                 members vlan100;
+#             }
+#         }
+#     }
+# }
+# ge-0/0/2 {
+#     description "Configured by Ansible";
+#     native-vlan-id 400;
+#     speed 10m;
+#     mtu 2048;
+#     hold-time up 3000 down 3200;
+#     unit 0 {
+#         family ethernet-switching {
+#             interface-mode trunk;
+#             vlan {
+#                 members [ vlan200 vlan300 ];
+#             }
+#         }
+#     }
+# }
+# em1 {
+#     description TEST;
+# }
+# fxp0 {
+#     description ANSIBLE;
+#     speed 1g;
+#     link-mode automatic;
+#     unit 0 {
+#         family inet {
+#             address 10.8.38.38/24;
+#         }
+#     }
+# }
 
 """
 RETURN = """

--- a/tests/integration/targets/junos_l2_interfaces/tests/netconf/fixtures/parsed.cfg
+++ b/tests/integration/targets/junos_l2_interfaces/tests/netconf/fixtures/parsed.cfg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply message-id="urn:uuid:0cadb4e8-5bba-47f4-986e-72906227007f">
+    <configuration changed-seconds="1590139550" changed-localtime="2020-05-22 09:25:50 UTC">
+        <interfaces>
+            <interface>
+                <name>ge-0/0/1</name>
+                <description>Configured by Ansible</description>
+                <disable/>
+                <speed>100m</speed>
+                <mtu>1024</mtu>
+                <hold-time>
+                    <up>2000</up>
+                    <down>2200</down>
+                </hold-time>
+                <link-mode>full-duplex</link-mode>
+                <unit>
+                    <name>0</name>
+                    <family>
+                        <ethernet-switching>
+                            <interface-mode>access</interface-mode>
+                            <vlan>
+                                <members>vlan100</members>
+                            </vlan>
+                        </ethernet-switching>
+                    </family>
+                </unit>
+            </interface>
+            <interface>
+                <name>ge-0/0/2</name>
+                <description>Configured by Ansible</description>
+                <native-vlan-id>400</native-vlan-id>
+                <speed>10m</speed>
+                <mtu>2048</mtu>
+                <hold-time>
+                    <up>3000</up>
+                    <down>3200</down>
+                </hold-time>
+                <unit>
+                    <name>0</name>
+                    <family>
+                        <ethernet-switching>
+                            <interface-mode>trunk</interface-mode>
+                            <vlan>
+                                <members>vlan200</members>
+                                <members>vlan300</members>
+                            </vlan>
+                        </ethernet-switching>
+                    </family>
+                </unit>
+            </interface>
+        </interfaces>
+    </configuration>
+</rpc-reply>

--- a/tests/integration/targets/junos_l2_interfaces/tests/netconf/gathered.yaml
+++ b/tests/integration/targets/junos_l2_interfaces/tests/netconf/gathered.yaml
@@ -1,0 +1,63 @@
+---
+- debug:
+    msg: START junos_l2_interfaces gathered integration tests on connection={{
+      ansible_connection }}
+
+- include_tasks: _remove_config.yaml
+
+- include_tasks: _base_config.yaml
+
+- set_fact:
+    expected_merged_output:
+
+      - name: ge-0/0/1
+        access:
+          vlan: vlan100
+        enhanced_layer: true
+        unit: 0
+
+      - name: ge-0/0/2
+        trunk:
+          allowed_vlans:
+            - vlan200
+            - vlan300
+          native_vlan: '400'
+        enhanced_layer: true
+        unit: 0
+
+- block:
+
+    - name: Merge the provided configuration with the exisiting running configuration
+      register: result
+      junipernetworks.junos.junos_l2_interfaces:
+        config:
+
+          - name: ge-0/0/1
+            access:
+              vlan: vlan100
+
+          - name: ge-0/0/2
+            trunk:
+              allowed_vlans:
+                - vlan200
+                - vlan300
+              native_vlan: '400'
+        state: merged
+
+    - name: Gather l2_interfaces facts using gathered state
+      register: result
+      junipernetworks.junos.junos_l2_interfaces:
+        state: gathered
+
+    - name: Assert that facts were correctly generated
+      assert:
+        that: "{{ expected_merged_output | symmetric_difference(result['gathered']) |length\
+          \ == 0 }}"
+
+  always:
+
+    - include_tasks: _remove_config.yaml
+
+- debug:
+    msg: END junos_l2_interfaces gathered integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/junos_l2_interfaces/tests/netconf/parsed.yaml
+++ b/tests/integration/targets/junos_l2_interfaces/tests/netconf/parsed.yaml
@@ -1,0 +1,37 @@
+---
+- debug:
+    msg: START junos_l2_interfaces parsed integration tests on connection={{ ansible_connection
+      }}
+
+- set_fact:
+    expected_parsed_output:
+
+      - name: ge-0/0/1
+        access:
+          vlan: vlan100
+        enhanced_layer: true
+        unit: 0
+
+      - name: ge-0/0/2
+        trunk:
+          allowed_vlans:
+            - vlan200
+            - vlan300
+          native_vlan: '400'
+        enhanced_layer: true
+        unit: 0
+
+- name: Parse externally provided interfaces config to agnostic model
+  register: result
+  junipernetworks.junos.junos_l2_interfaces:
+    running_config: "{{ lookup('file', './fixtures/parsed.cfg') }}"
+    state: parsed
+
+- name: Assert that config was correctly parsed
+  assert:
+    that:
+      - "{{ expected_parsed_output | symmetric_difference(result['parsed']) |length ==\
+        \ 0 }}"
+- debug:
+    msg: END junos_l2_interfaces parsed integration tests on connection={{ ansible_connection
+      }}

--- a/tests/integration/targets/junos_l2_interfaces/tests/netconf/rendered.yaml
+++ b/tests/integration/targets/junos_l2_interfaces/tests/netconf/rendered.yaml
@@ -1,0 +1,63 @@
+---
+- debug:
+    msg: START junos_l2_interfaces rendered integration tests on connection={{
+      ansible_connection }}
+
+- set_fact:
+    expected_rendered_output: "<nc:interfaces
+                                   xmlns:nc=\"urn:ietf:params:xml:ns:netconf:base:1.0\">
+                                   <nc:interface>
+                                       <nc:name>ge-0/0/1</nc:name>
+                                       <nc:unit>
+                                           <nc:name>0</nc:name>
+                                           <nc:family>
+                                               <nc:ethernet-switching>
+                                                   <nc:interface-mode>access</nc:interface-mode>
+                                                   <nc:vlan>
+                                                       <nc:members>vlan100</nc:members>
+                                                   </nc:vlan>
+                                               </nc:ethernet-switching>
+                                           </nc:family>
+                                       </nc:unit>
+                                   </nc:interface>
+                                   <nc:interface>
+                                       <nc:name>ge-0/0/2</nc:name>
+                                       <nc:unit>
+                                           <nc:name>0</nc:name>
+                                           <nc:family>
+                                               <nc:ethernet-switching>
+                                                   <nc:interface-mode>trunk</nc:interface-mode>
+                                                   <nc:vlan>
+                                                       <nc:members>vlan200</nc:members>
+                                                       <nc:members>vlan300</nc:members>
+                                                   </nc:vlan>
+                                               </nc:ethernet-switching>
+                                           </nc:family>
+                                       </nc:unit>
+                                       <nc:native-vlan-id>400</nc:native-vlan-id>
+                                   </nc:interface>
+                               </nc:interfaces>"
+
+- name: Render platform specific commands from task input using rendered state
+  register: result
+  junipernetworks.junos.junos_l2_interfaces:
+    config:
+      - name: ge-0/0/1
+        access:
+          vlan: vlan100
+      - name: ge-0/0/2
+        trunk:
+          allowed_vlans:
+            - vlan200
+            - vlan300
+          native_vlan: '400'
+    state: rendered
+
+- name: Assert that correct set of commands were rendered
+  assert:
+    that:
+      - "{{ expected_rendered_output == result['rendered'] }}"
+
+- debug:
+    msg: END junos_l2_interfaces rendered integration tests on connection={{
+      ansible_connection }}


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
resolve : https://github.com/ansible-collections/junipernetworks.junos/issues/91
fixes traceback when provided `config` key value is empty.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junos_l2_interfaces
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
