### PR TITLE
Only wait for netconf when netconf is asked for

### DIFF
--- a/changelogs/fragments/int-test-fix.yaml
+++ b/changelogs/fragments/int-test-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Integration test tag fix

--- a/changelogs/fragments/int-test-fix.yaml
+++ b/changelogs/fragments/int-test-fix.yaml
@@ -1,3 +1,3 @@
 ---
-bugfixes:
+trivial:
   - Integration test tag fix

--- a/tests/integration/targets/prepare_junos_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_junos_tests/tasks/main.yml
@@ -9,6 +9,7 @@
 
 - name: wait for netconf server to come up
   delegate_to: localhost
+  tags: netconf
   wait_for:
     host: '{{ hostvars[item].ansible_host }}'
     port: 830


### PR DESCRIPTION
##### SUMMARY
Thinking we should only wait for netconf if we enabled it

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
integration test, prepare
##### ADDITIONAL INFORMATION
