### PR TITLE
Remove ansible from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ansible
 jxmlease
 ncclient
 paramiko


### PR DESCRIPTION
Due to how ansible / ansible-base now works, this actually breaks
testing of ansible/ansible devel jobs.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>