### PR TITLE
Add support for single_user_mode

### DIFF
--- a/changelogs/fragments/single_user_mode.yaml
+++ b/changelogs/fragments/single_user_mode.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Add support for configuration caching (single_user_mode).
+  - Re-use device_info dictionary in cliconf.

--- a/plugins/terminal/junos.py
+++ b/plugins/terminal/junos.py
@@ -42,6 +42,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"[\r\n]error:"),
     ]
 
+    terminal_config_prompt = re.compile(r"^.+#$")
+
     def on_open_shell(self):
         try:
             prompt = self._get_prompt()

--- a/tests/integration/targets/junos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/junos_smoke/tasks/cli.yaml
@@ -14,3 +14,8 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+
+- name: run test cases with single_user_mode (connection=network_cli)
+  include: "{{ role_path }}/tests/cli/caching.yaml ansible_connection=network_cli ansible_network_single_user_mode=True ansible_connection=network_cli connection={{ cli }}"
+  tags:
+    - network_cli

--- a/tests/integration/targets/junos_smoke/tests/cli/caching.yaml
+++ b/tests/integration/targets/junos_smoke/tests/cli/caching.yaml
@@ -1,0 +1,52 @@
+---
+- block:
+  - debug: msg="START connection={{ ansible_connection }} cli/caching.yaml"
+
+  - name: Remove description from interface
+    ignore_errors: true
+    junipernetworks.junos.junos_command: &rem
+      commands:
+        - configure
+        - delete interfaces ge-0/0/1 description
+        - commit
+        - exit
+
+  - name: Fetch configuration
+    ignore_errors: true
+    junipernetworks.junos.junos_command:
+      commands: show configuration interfaces ge-0/0/1
+    register: result
+
+  - assert:
+      that:
+        - '"description test-1;" not in result.stdout_lines'
+
+  - name: Fetch configuration again (from cache)
+    ignore_errors: true
+    junipernetworks.junos.junos_command:
+      commands: show configuration interfaces ge-0/0/1
+
+  - name: Configure description on interface
+    ignore_errors: true
+    junipernetworks.junos.junos_command:
+      commands:
+        - configure
+        - set interfaces ge-0/0/1 description test-1
+        - commit
+        - exit
+
+  - name: Fetch configuration from appliance
+    ignore_errors: true
+    junipernetworks.junos.junos_command:
+      commands: show configuration interfaces ge-0/0/1
+    register: result
+
+  - assert:
+      that:
+        - '"description test-1;" in result.stdout_lines[0]'
+
+  always:
+    - name: Remove description from interface
+      ignore_errors: true
+      junipernetworks.junos.junos_command: *rem
+  when: ansible_connection == "network_cli" and ansible_network_single_user_mode|d(False)


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/junipernetworks.junos/pull/150

Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

##### SUMMARY
- Targets ansible-collections/ansible.netcommon#73
- Add support for ansible_single_user_mode option added in network_cli.
- Re-use device_info dictionary for every session.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
cliconf/junos.py
terminal/junos.py