### PR TITLE
vlan_id not vlan-id

### DIFF
--- a/changelogs/fragments/junos_vlans.yaml
+++ b/changelogs/fragments/junos_vlans.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+          - Replace unsupported parameter `vlan-id` in junipernetworks.junos.junos_vlans module with `vlan_id`

--- a/docs/junipernetworks.junos.junos_vlans_module.rst
+++ b/docs/junipernetworks.junos.junos_vlans_module.rst
@@ -183,29 +183,29 @@ Examples
       junipernetworks.junos.junos_vlans:
         config:
         - name: vlan-1
-          vlan-id: 1
-      state: merged
+          vlan_id: 1
+        state: merged
     - name: Replace JUNOS vlan
       junipernetworks.junos.junos_vlans:
         config:
         - name: vlan-1
-          vlan-id: 10
+          vlan_id: 10
         - name: vlan-3
-          vlan-id: 30
-      state: replaced
+          vlan_id: 30
+        state: replaced
     - name: Override JUNOS vlan
       junipernetworks.junos.junos_vlans:
         config:
         - name: vlan-4
-          vlan-id: 100
+          vlan_id: 100
         - name: vlan-2
-          vlan-id: 200
-      state: overridden
+          vlan_id: 200
+        state: overridden
     - name: Delete JUNOS vlan
       junipernetworks.junos.junos_vlans:
         config:
         - name: vlan-1
-      state: deleted
+        state: deleted
 
 
 

--- a/plugins/modules/junos_vlans.py
+++ b/plugins/modules/junos_vlans.py
@@ -107,29 +107,29 @@ EXAMPLES = """
   junipernetworks.junos.junos_vlans:
     config:
     - name: vlan-1
-      vlan-id: 1
-  state: merged
+      vlan_id: 1
+    state: merged
 - name: Replace JUNOS vlan
   junipernetworks.junos.junos_vlans:
     config:
     - name: vlan-1
-      vlan-id: 10
+      vlan_id: 10
     - name: vlan-3
-      vlan-id: 30
-  state: replaced
+      vlan_id: 30
+    state: replaced
 - name: Override JUNOS vlan
   junipernetworks.junos.junos_vlans:
     config:
     - name: vlan-4
-      vlan-id: 100
+      vlan_id: 100
     - name: vlan-2
-      vlan-id: 200
-  state: overridden
+      vlan_id: 200
+    state: overridden
 - name: Delete JUNOS vlan
   junipernetworks.junos.junos_vlans:
     config:
     - name: vlan-1
-  state: deleted
+    state: deleted
 """
 
 RETURN = """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`vlan-id` is an unsupported parameter for the `junipernetworks.junos.junos_vlans` module. It expects vlan_id` instead
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Module `junos_vlans` and its associate doc page, `junos_vlans_module`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1. When I tried to create a vlan based on the example provided in this page, I got the following error message
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
fatal: [uranus]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (junipernetworks.junos.junos_vlans) module: vlan-id found in config. Supported parameters include: description, name, vlan_id"}
```
Checking the code on github (to insure I was not editing an old review), I saw that `vlan_id` is the parameter defined in `./plugins/modules/junos_vlans.py`
2. `state` parameter in examples should be moved to the right 2 spaces. So, if we run the example
```
- name: Merge JUNOS vlan
  junipernetworks.junos.junos_vlans:
    config:
    - name: vlan-1
      vlan-id: 1
  state: merged
```
we will get the error message
```bash
ERROR! conflicting action statements: state, junipernetworks.junos.junos_vlans
```
The solution is to change it (yes, we also changed `vlan-id` to `vlan_id` while at it) to
```
- name: Merge JUNOS vlan
  junipernetworks.junos.junos_vlans:
    config:
    - name: vlan-1
      vlan_id: 1
    state: merged
```