### PR TITLE
Change src element from str to path for junos_scp.

### DIFF
--- a/changelogs/fragments/change_junos_scp_src_element.yaml
+++ b/changelogs/fragments/change_junos_scp_src_element.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Change src element from str to path for junos_scp.

--- a/plugins/modules/junos_scp.py
+++ b/plugins/modules/junos_scp.py
@@ -25,7 +25,7 @@ options:
       The argument C(recursive) must be C(true) to transfer directories.
     required: true
     type: list
-    elements: str
+    elements: path
   dest:
     description:
     - The C(dest) argument specifies the path in which to receive the files.
@@ -129,7 +129,7 @@ def main():
     """ Main entry point for Ansible module execution
     """
     argument_spec = dict(
-        src=dict(type="list", required=True, elements="str"),
+        src=dict(type="list", required=True, elements="path"),
         dest=dict(type="path", required=False, default="."),
         recursive=dict(type="bool", default=False),
         remote_src=dict(type="bool", default=False),

--- a/tests/unit/modules/network/junos/test_junos_scp.py
+++ b/tests/unit/modules/network/junos/test_junos_scp.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+import os
+
 from ansible_collections.junipernetworks.junos.tests.unit.compat.mock import (
     patch,
     MagicMock,
@@ -72,6 +74,14 @@ class TestJunosScpModule(TestJunosModule):
 
         self.scp_mock.put.assert_called_once_with(
             "test.txt", remote_path=".", recursive=False
+        )
+
+    def test_junos_scp_src_expand_tilde(self):
+        set_module_args(dict(src="~/test.txt"))
+        self.execute_module(changed=True)
+
+        self.scp_mock.put.assert_called_once_with(
+            os.path.expanduser("~/test.txt"), remote_path=".", recursive=False
         )
 
     def test_junos_scp_src_fail(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Change src element from str to path for junos_scp.

`src` parameter cannot expand "\~".
But `dest` parameter can expand "\~".
I aligned the behavior of `src` and `dest`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- junos_scp
