### PR TITLE
Fix no port-priority supplied

### DIFF
--- a/changelogs/fragments/fix_no_port_priority.yml
+++ b/changelogs/fragments/fix_no_port_priority.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix lacp force-up without port-priority in junos_lacp_interfaces

--- a/changelogs/fragments/fix_no_port_priority.yml
+++ b/changelogs/fragments/fix_no_port_priority.yml
@@ -1,3 +1,4 @@
 ---
 bugfixes:
   - fix lacp force-up without port-priority in junos_lacp_interfaces
+  - fix netconf test-case for lacp revert

--- a/plugins/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
+++ b/plugins/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
@@ -251,12 +251,12 @@ class Lacp_interfaces(ConfigBase):
                     build_child_xml_node(
                         element, "port-priority", None, {"delete": "delete"}
                     )
-                if config["force_up"] is False:
+                if config["force_up"]:
+                    build_child_xml_node(element, "force-up")
+                else:
                     build_child_xml_node(
                         element, "force-up", None, {"delete": "delete"}
                     )
-                else:
-                    build_child_xml_node(element, "force-up")
                 intf_xml.append(lacp_intf_root)
 
         return intf_xml

--- a/plugins/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
+++ b/plugins/module_utils/network/junos/config/lacp_interfaces/lacp_interfaces.py
@@ -243,9 +243,14 @@ class Lacp_interfaces(ConfigBase):
                 element = build_subtree(
                     lacp_intf_root, "ether-options/ieee-802.3ad/lacp"
                 )
-                build_child_xml_node(
-                    element, "port-priority", config["port_priority"]
-                )
+                if config["port_priority"] is not None:
+                    build_child_xml_node(
+                        element, "port-priority", config["port_priority"]
+                    )
+                else:
+                    build_child_xml_node(
+                        element, "port-priority", None, {"delete": "delete"}
+                    )
                 if config["force_up"] is False:
                     build_child_xml_node(
                         element, "force-up", None, {"delete": "delete"}

--- a/tests/integration/targets/junos_lacp_interfaces/tests/netconf/rtt.yaml
+++ b/tests/integration/targets/junos_lacp_interfaces/tests/netconf/rtt.yaml
@@ -8,7 +8,7 @@
 - include_tasks: _base_config.yaml
 
 - set_fact:
-    expected_revert_output:
+    expected_revert_output: &base_config
 
       - name: ae1
         period: slow
@@ -36,28 +36,7 @@
     - name: Apply the provided configuration (base config)
       register: base_config
       junipernetworks.junos.junos_lacp_interfaces:
-        config:
-
-          - name: ae1
-            period: slow
-            sync_reset: disable
-            system:
-              priority: 10
-              mac:
-                address: 00:00:00:00:00:03
-
-          - name: ge-0/0/2
-            port_priority: 250
-            force_up: false
-
-          - name: ae2
-            period: fast
-            system:
-              priority: 300
-
-          - name: ge-0/0/4
-            port_priority: 400
-            force_up: true
+        config: *base_config
         state: merged
 
     - name: Gather interfaces facts


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The primary fix is for a crash where force_up is supplied, but port_priority is not. It also makes an attempt to clean up some of the logic surrounding the bug mentioned.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
junipernetworks.junos.junos_lacp_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This code will produce an error, as port_priority is not supplied.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: configure lacp force-up
  junipernetworks.junos.junos_lacp_interfaces:
    config:
      - name: ge-0/0/0
        force_up: yes
```
