### PR TITLE
deprecate router_id option from ospfv3 resource module

### DIFF
--- a/changelogs/fragments/deprecate_ospfv3_router_id.yaml
+++ b/changelogs/fragments/deprecate_ospfv3_router_id.yaml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+  - Deprecated router_id from ospfv3 resource module.

--- a/docs/junipernetworks.junos.junos_ospfv3_module.rst
+++ b/docs/junipernetworks.junos.junos_ospfv3_module.rst
@@ -629,13 +629,14 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>The OSPFv3 router id.</div>
+                        <div>This option is DEPRECATED and will be replaced with router_id attribute of junos_routing_options resource_module.</div>
+                        <div>This attribute will be removed after 2024-01-01.</div>
                 </td>
             </tr>
             <tr>
@@ -777,8 +778,7 @@ Examples
     - name: Merge Junos OSPFv3 config
       junipernetworks.junos.junos_ospfv3:
         config:
-        - router_id: 10.200.16.75
-          areas:
+        - areas:
             - area_id: 0.0.0.100
               stub:
                 default_metric: 200
@@ -816,8 +816,7 @@ Examples
     - name: Replace Junos OSPFv3 config
       junipernetworks.junos.junos_ospfv3:
        config:
-         - router_id: 10.200.16.75
-           areas:
+         - areas:
              - area_id: 0.0.0.100
                interfaces:
                  - name: so-0/0/0.0
@@ -842,8 +841,7 @@ Examples
     - name: Override Junos OSPFv3 config
       junipernetworks.junos.junos_ospfv3:
       config:
-        - router_id: 10.200.16.75
-          areas:
+        - areas:
             - area_id: 0.0.0.100
               stub:
                 default_metric: 200
@@ -895,8 +893,7 @@ Examples
     - name: Delete Junos OSPFv3 config
       junipernetworks.junos.junos_ospfv3:
         config:
-          - router_id: 10.200.16.75
-            areas:
+          - areas:
               - area_id: 0.0.0.100
                 interfaces:
                   - name: so-0/0/0.0
@@ -966,7 +963,6 @@ Examples
     #                     ]
     #                 }
     #             ],
-    #             "router_id": "10.200.16.75"
     #         }
     #
     # Using rendered
@@ -975,8 +971,7 @@ Examples
     - name: Render the commands for provided  configuration
       junipernetworks.junos.junos_ospfv3:
         config:
-        - router_id: 10.200.16.75
-          areas:
+        - areas:
             - area_id: 0.0.0.100
               stub:
                 default_metric: 200
@@ -1145,7 +1140,6 @@ Examples
     #                     ]
     #                 }
     #             ],
-    #             "router_id": "10.200.16.75"
     #         }
     #     ]
     #

--- a/plugins/module_utils/network/junos/argspec/ospfv3/ospfv3.py
+++ b/plugins/module_utils/network/junos/argspec/ospfv3/ospfv3.py
@@ -33,7 +33,7 @@ class Ospfv3Args(object):  # pylint: disable=R0903
         "config": {
             "elements": "dict",
             "options": {
-                "router_id": {"required": True, "type": "str"},
+                "router_id": {"type": "str"},
                 "areas": {
                     "elements": "dict",
                     "options": {

--- a/plugins/modules/junos_ospfv3.py
+++ b/plugins/modules/junos_ospfv3.py
@@ -54,8 +54,10 @@ options:
       router_id:
         description:
         - The OSPFv3 router id.
+        - This option is DEPRECATED and will be replaced with router_id attribute of
+          junos_routing_options resource_module.
+        - This attribute will be removed after 2024-01-01.
         type: str
-        required: true
       areas:
         description:
         - A list of OSPFv3 areas' configuration.
@@ -235,8 +237,7 @@ EXAMPLES = """
 - name: Merge Junos OSPFv3 config
   junipernetworks.junos.junos_ospfv3:
     config:
-    - router_id: 10.200.16.75
-      areas:
+    - areas:
         - area_id: 0.0.0.100
           stub:
             default_metric: 200
@@ -274,8 +275,7 @@ EXAMPLES = """
 - name: Replace Junos OSPFv3 config
   junipernetworks.junos.junos_ospfv3:
    config:
-     - router_id: 10.200.16.75
-       areas:
+     - areas:
          - area_id: 0.0.0.100
            interfaces:
              - name: so-0/0/0.0
@@ -300,8 +300,7 @@ EXAMPLES = """
 - name: Override Junos OSPFv3 config
   junipernetworks.junos.junos_ospfv3:
   config:
-    - router_id: 10.200.16.75
-      areas:
+    - areas:
         - area_id: 0.0.0.100
           stub:
             default_metric: 200
@@ -353,8 +352,7 @@ EXAMPLES = """
 - name: Delete Junos OSPFv3 config
   junipernetworks.junos.junos_ospfv3:
     config:
-      - router_id: 10.200.16.75
-        areas:
+      - areas:
           - area_id: 0.0.0.100
             interfaces:
               - name: so-0/0/0.0
@@ -424,7 +422,6 @@ EXAMPLES = """
 #                     ]
 #                 }
 #             ],
-#             "router_id": "10.200.16.75"
 #         }
 #
 # Using rendered
@@ -433,8 +430,7 @@ EXAMPLES = """
 - name: Render the commands for provided  configuration
   junipernetworks.junos.junos_ospfv3:
     config:
-    - router_id: 10.200.16.75
-      areas:
+    - areas:
         - area_id: 0.0.0.100
           stub:
             default_metric: 200
@@ -603,7 +599,6 @@ EXAMPLES = """
 #                     ]
 #                 }
 #             ],
-#             "router_id": "10.200.16.75"
 #         }
 #     ]
 #


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
