### PR TITLE
Junos: Rename peers sub-option attribute  `key` to `key_id`

### DIFF
--- a/changelogs/fragments/rename_key_to_key_id_junos_ntp_global.yaml
+++ b/changelogs/fragments/rename_key_to_key_id_junos_ntp_global.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Update peers suboption key attribute to key_id.

--- a/plugins/module_utils/network/junos/argspec/ntp_global/ntp_global.py
+++ b/plugins/module_utils/network/junos/argspec/ntp_global/ntp_global.py
@@ -71,7 +71,7 @@ class Ntp_globalArgs(object):  # pylint: disable=R0903
                 "peers": {
                     "elements": "dict",
                     "options": {
-                        "key": {"type": "int", "no_log": False},
+                        "key_id": {"type": "int", "no_log": False},
                         "peer": {"type": "str"},
                         "prefer": {"type": "bool"},
                         "version": {"type": "int"},

--- a/plugins/module_utils/network/junos/config/ntp_global/ntp_global.py
+++ b/plugins/module_utils/network/junos/config/ntp_global/ntp_global.py
@@ -266,8 +266,8 @@ class Ntp_global(ConfigBase):
                 # add name node
                 build_child_xml_node(peer_node, "name", item.get("peer"))
                 # add key node
-                if "key" in item.keys():
-                    build_child_xml_node(peer_node, "key", item.get("key"))
+                if "key_id" in item.keys():
+                    build_child_xml_node(peer_node, "key", item.get("key_id"))
                 # add prefer node
                 if "prefer" in item.keys() and item.get("prefer"):
                     build_child_xml_node(peer_node, "prefer")

--- a/plugins/module_utils/network/junos/facts/ntp_global/ntp_global.py
+++ b/plugins/module_utils/network/junos/facts/ntp_global/ntp_global.py
@@ -218,7 +218,7 @@ class Ntp_globalFacts(object):
             if isinstance(peers, dict):
                 peer_dict["peer"] = peers["name"]
                 if "key" in peers.keys():
-                    peer_dict["key"] = peers["key"]
+                    peer_dict["key_id"] = peers["key"]
                 if "prefer" in peers.keys():
                     peer_dict["prefer"] = True
                 if "version" in peers.keys():
@@ -229,7 +229,7 @@ class Ntp_globalFacts(object):
                 for peer in peers:
                     peer_dict["peer"] = peer["name"]
                     if "key" in peer.keys():
-                        peer_dict["key"] = peer["key"]
+                        peer_dict["key_id"] = peer["key"]
                     if "prefer" in peer.keys():
                         peer_dict["prefer"] = True
                     if "version" in peer.keys():

--- a/plugins/modules/junos_ntp_global.py
+++ b/plugins/modules/junos_ntp_global.py
@@ -113,7 +113,7 @@ options:
           peer:
             description: Hostname/IP address of the NTP Peer.
             type: str
-          key:
+          key_id:
             description: Key-id to be used while communicating.
             type: int
           prefer:
@@ -224,7 +224,7 @@ EXAMPLES = """
       peers:
         - peer: "78.44.194.186"
         - peer: "172.44.194.186"
-          key: 10000
+          key_id: 10000
           prefer: true
           version: 3
       servers:
@@ -279,7 +279,7 @@ EXAMPLES = """
 #                 "peer": "78.44.194.186"
 #             },
 #             {
-#                 "key": 10000,
+#                 "key_id": 10000,
 #                 "peer": "172.44.194.186",
 #                 "prefer": true,
 #                 "version": 3
@@ -458,7 +458,7 @@ EXAMPLES = """
 #                 "peer": "78.44.194.186"
 #             },
 #             {
-#                 "key": 10000,
+#                 "key_id": 10000,
 #                 "peer": "172.44.194.186",
 #                 "prefer": true,
 #                 "version": 3
@@ -618,7 +618,7 @@ EXAMPLES = """
 #                 "peer": "78.44.194.186"
 #             },
 #             {
-#                 "key": 10000,
+#                 "key_id": 10000,
 #                 "peer": "172.44.194.186",
 #                 "prefer": true,
 #                 "version": 3
@@ -790,7 +790,7 @@ EXAMPLES = """
 #                 "peer": "78.44.194.186"
 #             },
 #             {
-#                 "key": 10000,
+#                 "key_id": 10000,
 #                 "peer": "172.44.194.186",
 #                 "prefer": true,
 #                 "version": 3
@@ -857,7 +857,7 @@ EXAMPLES = """
       peers:
         - peer: "78.44.194.186"
         - peer: "172.44.194.186"
-          key: 10000
+          key_id: 10000
           prefer: true
           version: 3
       servers:

--- a/tests/integration/targets/junos_ntp_global/tests/netconf/merged.yaml
+++ b/tests/integration/targets/junos_ntp_global/tests/netconf/merged.yaml
@@ -27,7 +27,7 @@
           peers:
             - peer: "78.44.194.186"
             - peer: "172.44.194.186"
-              key: 10000
+              key_id: 10000
               prefer: true
               version: 3
           servers:
@@ -78,7 +78,7 @@
           interval_range: 3
           peers:
             - peer: "172.44.194.188"
-              key: 10000
+              key_id: 10000
               prefer: true
               version: 3
       register: result

--- a/tests/integration/targets/junos_ntp_global/tests/netconf/overridden.yaml
+++ b/tests/integration/targets/junos_ntp_global/tests/netconf/overridden.yaml
@@ -14,7 +14,7 @@
           interval_range: 3
           peers:
             - peer: "172.44.194.188"
-              key: 10000
+              key_id: 10000
               prefer: true
               version: 3
         state: overridden

--- a/tests/integration/targets/junos_ntp_global/tests/netconf/rendered.yaml
+++ b/tests/integration/targets/junos_ntp_global/tests/netconf/rendered.yaml
@@ -15,7 +15,7 @@
       peers:
         - peer: "78.44.194.186"
         - peer: "172.44.194.186"
-          key: 10000
+          key_id: 10000
           prefer: true
           version: 3
     state: rendered

--- a/tests/integration/targets/junos_ntp_global/tests/netconf/replaced.yaml
+++ b/tests/integration/targets/junos_ntp_global/tests/netconf/replaced.yaml
@@ -14,7 +14,7 @@
           interval_range: 3
           peers:
             - peer: "172.44.194.188"
-              key: 10000
+              key_id: 10000
               prefer: true
               version: 3
         state: replaced

--- a/tests/integration/targets/junos_ntp_global/tests/netconf/rtt.yml
+++ b/tests/integration/targets/junos_ntp_global/tests/netconf/rtt.yml
@@ -29,7 +29,7 @@
           peers:
             - peer: "78.44.194.186"
             - peer: "172.44.194.186"
-              key: 10000
+              key_id: 10000
               prefer: true
               version: 3
           servers:
@@ -70,7 +70,7 @@
           interval_range: 3
           peers:
             - peer: "172.44.194.188"
-              key: 10000
+              key_id: 10000
               prefer: true
               version: 3
         state: replaced

--- a/tests/integration/targets/junos_ntp_global/vars/main.yaml
+++ b/tests/integration/targets/junos_ntp_global/vars/main.yaml
@@ -20,7 +20,7 @@ merged:
     multicast_client: "224.0.0.1"
     peers:
       - peer: "78.44.194.186"
-      - key: 10000
+      - key_id: 10000
         peer: "172.44.194.186"
         prefer: true
         version: 3
@@ -65,11 +65,11 @@ merged:
     peers:
       - peer: "78.44.194.186"
       - peer: "172.44.194.186"
-        key: 10000
+        key_id: 10000
         prefer: true
         version: 3
       - peer: "172.44.194.188"
-        key: 10000
+        key_id: 10000
         prefer: true
         version: 3
     servers:
@@ -99,6 +99,6 @@ replaced:
     multicast_client: "224.0.0.1"
     peers:
       - peer: "172.44.194.188"
-        key: 10000
+        key_id: 10000
         prefer: true
         version: 3

--- a/tests/unit/modules/network/junos/test_junos_ntp_global.py
+++ b/tests/unit/modules/network/junos/test_junos_ntp_global.py
@@ -114,7 +114,7 @@ class TestJunosNtp_globalModule(TestJunosModule):
                         dict(peer="78.44.194.186"),
                         dict(
                             peer="172.44.194.186",
-                            key="10000",
+                            key_id="10000",
                             prefer=True,
                             version=3,
                         ),
@@ -315,7 +315,7 @@ class TestJunosNtp_globalModule(TestJunosModule):
             "peers": [
                 {"peer": "78.44.194.186"},
                 {
-                    "key": 10000,
+                    "key_id": 10000,
                     "peer": "172.44.194.186",
                     "prefer": True,
                     "version": 3,
@@ -427,7 +427,7 @@ class TestJunosNtp_globalModule(TestJunosModule):
             "multicast_client": "224.0.0.1",
             "peers": [
                 {
-                    "key": 10000,
+                    "key_id": 10000,
                     "peer": "172.44.194.186",
                     "prefer": True,
                     "version": 3,
@@ -527,7 +527,7 @@ class TestJunosNtp_globalModule(TestJunosModule):
                         dict(peer="78.44.194.186"),
                         dict(
                             peer="172.44.194.186",
-                            key="10000",
+                            key_id="10000",
                             prefer=True,
                             version=3,
                         ),
@@ -661,7 +661,7 @@ class TestJunosNtp_globalModule(TestJunosModule):
                         dict(peer="78.44.194.186"),
                         dict(
                             peer="172.44.194.186",
-                            key="10000",
+                            key_id="10000",
                             prefer=True,
                             version=3,
                         ),


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
