### PR TITLE
deprecate router-id option from ospf_interfaces

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -4,3 +4,5 @@
 gcc-c++ [doc test platform:rpm]
 python3-devel [test platform:rpm]
 python3 [test platform:rpm]
+libssh-devel [test platform:rpm]
+libssh-dev [test platform:dpkg]

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -26,5 +26,7 @@ sections:
   - Bugfixes
 - - known_issues
   - Known Issues
+- - doc_changes
+  - Documentation Changes
 title: Junipernetworks Junos Collection
 trivial_section_name: trivial

--- a/changelogs/fragments/junos_ospf_router_if_fix.yaml
+++ b/changelogs/fragments/junos_ospf_router_if_fix.yaml
@@ -1,0 +1,4 @@
+---
+doc_changes:
+  - Add note for router_id deprecation from ospf-interfaces resource module.
+  - make sure router_id facts and config operation works fine for ospfv2 and ospfv3 RM

--- a/docs/junipernetworks.junos.junos_ospf_interfaces_module.rst
+++ b/docs/junipernetworks.junos.junos_ospf_interfaces_module.rst
@@ -754,13 +754,14 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>The OSPFv3 router id.</div>
+                        <div>This option is DEPRECATED and will be replaced with router_id attribute of junos_routing_options resource_module.</div>
+                        <div>This attribute will be removed after 2024-01-01.</div>
                 </td>
             </tr>
 
@@ -834,8 +835,7 @@ Examples
     - name: Merge Junos OSPF interfaces config
       junipernetworks.junos.junos_ospf_interfaces:
         config:
-        - router_id: '10.200.16.75'
-          name: 'ge-0/0/2.0'
+        - name: 'ge-0/0/2.0'
           address_family:
             - afi: 'ipv4'
               processes:
@@ -871,8 +871,7 @@ Examples
     - name: Replace Junos OSPF interfaces config
       junipernetworks.junos.junos_ospf_interfaces:
        config:
-         - router_id: '10.200.16.75'
-           name: 'ge-0/0/2.0'
+         - name: 'ge-0/0/2.0'
            address_family:
              - afi: 'ipv4'
                processes:
@@ -915,8 +914,7 @@ Examples
     - name: Override Junos OSPF interfaces config
       junipernetworks.junos.junos_ospf_interfaces:
       config:
-        - router_id: '10.200.16.75'
-          name: 'ge-0/0/1.0'
+        - name: 'ge-0/0/1.0'
           address_family:
             - afi: 'ipv4'
               processes:
@@ -954,8 +952,7 @@ Examples
     - name: Delete Junos OSPF interfaces config
       junipernetworks.junos.junos_ospf_interfaces:
         config:
-          - router_id: '10.200.16.75'
-            name: 'ge-0/0/1.0'
+          - name: 'ge-0/0/1.0'
         state: deleted
 
     # After state
@@ -1006,7 +1003,6 @@ Examples
     #                 }
     #             ],
     #             "name": "ge-0/0/3.0",
-    #             "router_id": "10.200.16.75"
     #         },
     #         {
     #             "address_family": [
@@ -1022,7 +1018,6 @@ Examples
     #                 }
     #             ],
     #             "name": "ge-0/0/2.0",
-    #             "router_id": "10.200.16.75"
     #         }
     #     ]
     #
@@ -1032,8 +1027,7 @@ Examples
     - name: Render the commands for provided  configuration
       junipernetworks.junos.junos_ospf_interfaces:
         config:
-        - router_id: '10.200.16.75'
-          name: 'ge-0/0/2.0'
+        - name: 'ge-0/0/2.0'
           address_family:
             - afi: 'ipv4'
               processes:
@@ -1119,7 +1113,6 @@ Examples
     #                 }
     #             ],
     #             "name": "ge-0/0/2.0",
-    #             "router_id": "10.200.16.75"
     #         }
     #     ]
     #

--- a/docs/junipernetworks.junos.junos_ping_module.rst
+++ b/docs/junipernetworks.junos.junos_ping_module.rst
@@ -345,7 +345,7 @@ Notes
 -----
 
 .. note::
-   - For a general purpose network module, see the :ref:`ansible.netcommon..net_ping <ansible.netcommon..net_ping_module>` module.
+   - For a general purpose network module, see the :ref:`ansible.netcommon.net_ping <ansible.netcommon.net_ping_module>` module.
    - For Windows targets, use the :ref:`ansible.windows.win_ping <ansible.windows.win_ping_module>` module instead.
    - For targets running Python, use the :ref:`ansible.builtin.ping <ansible.builtin.ping_module>` module instead.
    - This module works only with connection ``network_cli``.

--- a/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
@@ -40,7 +40,7 @@ class Ospf_interfacesArgs(object):  # pylint: disable=R0903
         "config": {
             "elements": "dict",
             "options": {
-                "router_id": {"required": True, "type": "str"},
+                "router_id": {"type": "str"},
                 "address_family": {
                     "elements": "dict",
                     "options": {

--- a/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
@@ -261,10 +261,11 @@ class Ospf_interfaces(ConfigBase):
         protocol = build_root_xml_node("ospf")
         for ospf_interfaces in want:
             ospf_interfaces = remove_empties(ospf_interfaces)
-            self.router_id = ospf_interfaces.get("router_id")
-            build_child_xml_node(
-                self.routing_options, "router-id", self.router_id
-            )
+            if "router-id" in ospf_interfaces.keys():
+                self.router_id = ospf_interfaces.get("router_id")
+                build_child_xml_node(
+                    self.routing_options, "router-id", self.router_id
+                )
             for af in ospf_interfaces["address_family"]:
                 area_node = build_child_xml_node(protocol, "area")
                 processes = af.get("processes")

--- a/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
@@ -261,7 +261,7 @@ class Ospf_interfaces(ConfigBase):
         protocol = build_root_xml_node("ospf")
         for ospf_interfaces in want:
             ospf_interfaces = remove_empties(ospf_interfaces)
-            if "router-id" in ospf_interfaces.keys():
+            if "router_id" in ospf_interfaces.keys():
                 self.router_id = ospf_interfaces.get("router_id")
                 build_child_xml_node(
                     self.routing_options, "router-id", self.router_id

--- a/plugins/module_utils/network/junos/config/ospfv2/ospfv2.py
+++ b/plugins/module_utils/network/junos/config/ospfv2/ospfv2.py
@@ -243,6 +243,7 @@ class Ospfv2(ConfigBase):
         ospf_xml = []
         protocol = build_root_xml_node("ospf")
         for ospf in want:
+            ospf = remove_empties(ospf)
             if "router_id" in ospf.keys():
                 self.routing_options = build_child_xml_node(
                     self.root, "routing-options"

--- a/plugins/module_utils/network/junos/config/ospfv3/ospfv3.py
+++ b/plugins/module_utils/network/junos/config/ospfv3/ospfv3.py
@@ -249,10 +249,11 @@ class Ospfv3(ConfigBase):
         protocol = build_root_xml_node("ospf3")
         for ospfv3 in want:
             ospfv3 = remove_empties(ospfv3)
-            self.router_id = ospfv3.get("router_id")
-            build_child_xml_node(
-                self.routing_options, "router-id", self.router_id
-            )
+            if "router_id" in ospfv3.keys():
+                self.router_id = ospfv3.get("router_id")
+                build_child_xml_node(
+                    self.routing_options, "router-id", self.router_id
+                )
 
             if ospfv3.get("spf_options"):
                 spf_options_node = build_child_xml_node(

--- a/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
@@ -102,6 +102,7 @@ class Ospf_interfacesFacts(object):
 
         resources = data.xpath("configuration/protocols/ospf")
         router_id_path = data.xpath("configuration/routing-options/router-id")
+
         if router_id_path:
             self.router_id = self._get_xml_dict(router_id_path.pop())
         else:
@@ -254,7 +255,8 @@ class Ospf_interfacesFacts(object):
                     address_family.append(af)
                     conf["address_family"] = address_family
                     conf["name"] = interface.get("name")
-                    conf["router_id"] = self.router_id["router-id"]
+                    if self.router_id:
+                        conf["router_id"] = self.router_id["router-id"]
                     remove_empties(conf)
                     ospf_interfaces_config.append(conf)
 

--- a/plugins/module_utils/network/junos/facts/ospfv3/ospfv3.py
+++ b/plugins/module_utils/network/junos/facts/ospfv3/ospfv3.py
@@ -284,5 +284,6 @@ class Ospfv3Facts(object):
             config["prefix_export_limit"] = ospfv3.get("prefix-export-limit")
             config["reference_bandwidth"] = ospfv3.get("reference-bandwidth")
             config["areas"] = rendered_areas
-            config["router_id"] = self.router_id["router-id"]
+            if self.router_id:
+                config["router_id"] = self.router_id["router-id"]
         return utils.remove_empties(config)

--- a/plugins/modules/junos_ospf_interfaces.py
+++ b/plugins/modules/junos_ospf_interfaces.py
@@ -60,8 +60,10 @@ options:
       router_id:
         description:
         - The OSPFv3 router id.
+        - This option is DEPRECATED and will be replaced with router_id attribute of
+          junos_routing_options resource_module.
+        - This attribute will be removed after 2024-01-01.
         type: str
-        required: true
       name:
         description:
           - Name/Identifier of the interface.
@@ -240,8 +242,7 @@ EXAMPLES = """
 - name: Merge Junos OSPF interfaces config
   junipernetworks.junos.junos_ospf_interfaces:
     config:
-    - router_id: '10.200.16.75'
-      name: 'ge-0/0/2.0'
+    - name: 'ge-0/0/2.0'
       address_family:
         - afi: 'ipv4'
           processes:
@@ -277,8 +278,7 @@ EXAMPLES = """
 - name: Replace Junos OSPF interfaces config
   junipernetworks.junos.junos_ospf_interfaces:
    config:
-     - router_id: '10.200.16.75'
-       name: 'ge-0/0/2.0'
+     - name: 'ge-0/0/2.0'
        address_family:
          - afi: 'ipv4'
            processes:
@@ -321,8 +321,7 @@ EXAMPLES = """
 - name: Override Junos OSPF interfaces config
   junipernetworks.junos.junos_ospf_interfaces:
   config:
-    - router_id: '10.200.16.75'
-      name: 'ge-0/0/1.0'
+    - name: 'ge-0/0/1.0'
       address_family:
         - afi: 'ipv4'
           processes:
@@ -360,8 +359,7 @@ EXAMPLES = """
 - name: Delete Junos OSPF interfaces config
   junipernetworks.junos.junos_ospf_interfaces:
     config:
-      - router_id: '10.200.16.75'
-        name: 'ge-0/0/1.0'
+      - name: 'ge-0/0/1.0'
     state: deleted
 
 # After state
@@ -412,7 +410,6 @@ EXAMPLES = """
 #                 }
 #             ],
 #             "name": "ge-0/0/3.0",
-#             "router_id": "10.200.16.75"
 #         },
 #         {
 #             "address_family": [
@@ -428,7 +425,6 @@ EXAMPLES = """
 #                 }
 #             ],
 #             "name": "ge-0/0/2.0",
-#             "router_id": "10.200.16.75"
 #         }
 #     ]
 #
@@ -438,8 +434,7 @@ EXAMPLES = """
 - name: Render the commands for provided  configuration
   junipernetworks.junos.junos_ospf_interfaces:
     config:
-    - router_id: '10.200.16.75'
-      name: 'ge-0/0/2.0'
+    - name: 'ge-0/0/2.0'
       address_family:
         - afi: 'ipv4'
           processes:
@@ -525,7 +520,6 @@ EXAMPLES = """
 #                 }
 #             ],
 #             "name": "ge-0/0/2.0",
-#             "router_id": "10.200.16.75"
 #         }
 #     ]
 #

--- a/plugins/modules/junos_ping.py
+++ b/plugins/modules/junos_ping.py
@@ -71,7 +71,7 @@ options:
     - present
     default: present
 notes:
-- For a general purpose network module, see the M(ansible.netcommon..net_ping) module.
+- For a general purpose network module, see the M(ansible.netcommon.net_ping) module.
 - For Windows targets, use the M(ansible.windows.win_ping) module instead.
 - For targets running Python, use the M(ansible.builtin.ping) module instead.
 - This module works only with connection C(network_cli).

--- a/tests/integration/targets/junos_ospf_interfaces/tests/netconf/fixtures/parse_ospf_router_id.cfg
+++ b/tests/integration/targets/junos_ospf_interfaces/tests/netconf/fixtures/parse_ospf_router_id.cfg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply message-id="urn:uuid:0cadb4e8-5bba-47f4-986e-72906227007f">
+    <configuration changed-seconds="1590139550" changed-localtime="2020-05-22 09:25:50 UTC">
+        <protocols>
+            <ospf>
+                <area>
+                    <name>0.0.0.2</name>
+                    <stub>
+                        <default-metric>200</default-metric>
+                    </stub>
+                    <interface>
+                        <name>ge-0/0/2.0</name>
+                        <metric>5</metric>
+                        <priority>3</priority>
+                    </interface>
+                </area>
+            </ospf>
+        </protocols>
+        <routing-options>
+            <router-id>10.200.16.75</router-id>
+        </routing-options>
+    </configuration>
+</rpc-reply>

--- a/tests/integration/targets/junos_ospf_interfaces/tests/netconf/fixtures/parsed.cfg
+++ b/tests/integration/targets/junos_ospf_interfaces/tests/netconf/fixtures/parsed.cfg
@@ -16,8 +16,5 @@
                 </area>
             </ospf>
         </protocols>
-        <routing-options>
-            <router-id>10.200.16.75</router-id>
-        </routing-options>
     </configuration>
 </rpc-reply>

--- a/tests/integration/targets/junos_ospf_interfaces/tests/netconf/parsed.yaml
+++ b/tests/integration/targets/junos_ospf_interfaces/tests/netconf/parsed.yaml
@@ -13,7 +13,6 @@
               metric: 5
               priority: 3
         name: 'ge-0/0/2.0'
-        router_id: '10.200.16.75'
 
 - name: Parse externally provided interfaces config to agnostic model
   register: result

--- a/tests/integration/targets/junos_ospf_interfaces/tests/netconf/parsed.yaml
+++ b/tests/integration/targets/junos_ospf_interfaces/tests/netconf/parsed.yaml
@@ -25,6 +25,31 @@
     that:
       - "{{ expected_parsed_output | symmetric_difference(result['parsed']) |length ==\
         \ 0 }}"
+
+- set_fact:
+    expected_parsed_output:
+      - address_family:
+          - afi: 'ipv4'
+            processes:
+              area:
+                area_id: '0.0.0.2'
+              metric: 5
+              priority: 3
+        name: 'ge-0/0/2.0'
+        router_id: '10.200.16.75'
+
+- name: Parse externally provided interfaces config to agnostic model
+  register: result
+  junipernetworks.junos.junos_ospf_interfaces:
+    running_config: "{{ lookup('file', './fixtures/parse_ospf_router_id.cfg') }}"
+    state: parsed
+
+- name: Assert that config was correctly parsed
+  assert:
+    that:
+      - "{{ expected_parsed_output | symmetric_difference(result['parsed']) |length ==\
+        \ 0 }}"
+
 - debug:
     msg: END junos_ospf_interfaces parsed integration tests on connection={{ ansible_connection
       }}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1236
resolve: 
[x] https://github.com/ansible-collections/junipernetworks.junos/issues/215
[x] https://github.com/ansible-collections/junipernetworks.junos/issues/198
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
