### PR TITLE
fix junos_command output for empty config

### DIFF
--- a/changelogs/fragments/249_fix_junos_command_output.yaml
+++ b/changelogs/fragments/249_fix_junos_command_output.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Fix junos command RM output for empty config response.
+  - Fix junos_command output when empty config response is received for show commands (https://github.com/ansible-collections/junipernetworks.junos/issues/249).

--- a/changelogs/fragments/249_fix_junos_command_output.yaml
+++ b/changelogs/fragments/249_fix_junos_command_output.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fix junos command RM output for empty config response.

--- a/tests/integration/targets/junos_command/tests/netconf_text/no_config.yaml
+++ b/tests/integration/targets/junos_command/tests/netconf_text/no_config.yaml
@@ -2,7 +2,7 @@
 - debug: msg="START netconf_text/no_config.yaml on connection={{ ansible_connection
     }}"
 
-- name: test bad condition
+- name: test handling of show command's empty response received from network device
   register: result
   ignore_errors: true
   junipernetworks.junos.junos_command:
@@ -14,6 +14,9 @@
 - assert:
     that:
       - result.failed == false
+      - result.changed == false
+      - result.stdout == [""]
+      - result.stdout_lines == [""]
 
 - debug: msg="END netconf_text/no_config.yaml on connection={{ ansible_connection
     }}"

--- a/tests/integration/targets/junos_command/tests/netconf_text/no_config.yaml
+++ b/tests/integration/targets/junos_command/tests/netconf_text/no_config.yaml
@@ -15,8 +15,8 @@
     that:
       - result.failed == false
       - result.changed == false
-      - result.stdout == [""]
-      - result.stdout_lines == [""]
+      - result.stdout|symmetric_difference([""]) == []
+      - result.stdout_lines|symmetric_difference([[""]]) == []
 
 - debug: msg="END netconf_text/no_config.yaml on connection={{ ansible_connection
     }}"

--- a/tests/integration/targets/junos_command/tests/netconf_text/no_config.yaml
+++ b/tests/integration/targets/junos_command/tests/netconf_text/no_config.yaml
@@ -1,0 +1,19 @@
+---
+- debug: msg="START netconf_text/no_config.yaml on connection={{ ansible_connection
+    }}"
+
+- name: test bad condition
+  register: result
+  ignore_errors: true
+  junipernetworks.junos.junos_command:
+    commands:
+      - show configuration system ntp
+    display: text
+    provider: '{{ netconf }}'
+
+- assert:
+    that:
+      - result.failed == false
+
+- debug: msg="END netconf_text/no_config.yaml on connection={{ ansible_connection
+    }}"


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>
resolve: https://github.com/ansible-collections/junipernetworks.junos/issues/249
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
