### PR TITLE
Remove pretty_print  param from call  to_text

### DIFF
--- a/changelogs/fragments/225_fix_to_string.yaml
+++ b/changelogs/fragments/225_fix_to_string.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Fix incorrect param pass to to_text.

--- a/changelogs/fragments/225_fix_to_string.yaml
+++ b/changelogs/fragments/225_fix_to_string.yaml
@@ -1,2 +1,3 @@
+---
 bugfixes:
   - Fix incorrect param pass to to_text.

--- a/plugins/module_utils/network/junos/junos.py
+++ b/plugins/module_utils/network/junos/junos.py
@@ -89,7 +89,6 @@ def tostring(element, encoding="UTF-8", pretty_print=False):
         return to_text(
             xml_to_string(element, encoding),
             encoding=encoding,
-            pretty_print=pretty_print,
         )
 
 


### PR DESCRIPTION
Signed-off-by: Rohit Thakur <rohitthakur2590@outlook.com>
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
