### PR TITLE
Bug fix fact chassis key names

### DIFF
--- a/changelogs/fragments/bug_fix_fact_chassis_key_names.yml
+++ b/changelogs/fragments/bug_fix_fact_chassis_key_names.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Using json and regex to dynamically rename all key names within the sub module chassis category."

--- a/plugins/module_utils/network/junos/facts/legacy/base.py
+++ b/plugins/module_utils/network/junos/facts/legacy/base.py
@@ -14,7 +14,8 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import platform
-
+import json
+import re
 
 try:
     import xmltodict
@@ -184,6 +185,8 @@ class Hardware(FactsBase):
                     mod["chassis_sub_module"] = self._get_xml_dict(obj)["chassis-module"][
                         "chassis-sub-module"
                     ]
+                    mod_key_rename = re.sub('("\S+-\S+":)', lambda m: m.group(1).replace('-', '_'), json.dumps(mod["chassis_sub_module"]))
+                    mod["chassis_sub_module"] = json.loads(mod_key_rename)
             modules.append(mod)
 
         self.facts["modules"] = modules


### PR DESCRIPTION
##### SUMMARY
Fixing disparity with the module sub chassis key names #355 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Modifying base.py for legacy chassis facts.

##### ADDITIONAL INFORMATION
Once the chassis sub module facts were returned, there was a disparity between the key names including '-' and '_'. Making them all be '_' makes it easier for users to call on key names using dot notation.

BEFORE:
```
"ansible_net_modules": [
    {
        "description": "MX480 Midplane",
        "model_number": "CHAS-BP-MX480-S",
        "name": "Midplane",
        "part_number": "710-017414",
        "serial_number": "TR3128",
        "version": "REV 05"
    },
    {
        "description": "Front Panel Display",
        "model_number": "CRAFT-MX480-S",
        "name": "FPM Board",
        "part_number": "710-017254",
        "serial_number": "KE1631",
        "version": "REV 02"
    },
    {
        "description": "PS 1.4-2.52kW; 90-264V AC in",
        "model_number": "PWR-MX480-2520-AC-S",
        "name": "PEM 0",
        "part_number": "740-029970",
        "serial_number": "QCS1601U04F",
        "version": "Rev 11"
    },
    {
        "description": "PS 1.4-2.52kW; 90-264V AC in",
        "model_number": "PWR-MX480-2520-AC-S",
        "name": "PEM 1",
        "part_number": "740-029970",
        "serial_number": "QCS1601U04P",
        "version": "Rev 11"
    },
    {
        "description": "PS 1.4-2.52kW; 90-264V AC in",
        "model_number": "PWR-MX480-2520-AC-S",
        "name": "PEM 2",
        "part_number": "740-029970",
        "serial_number": "QCS1601U0AF",
        "version": "Rev 11"
    },
    {
        "description": "PS 1.4-2.52kW; 90-264V AC in",
        "model_number": "PWR-MX480-2520-AC-S",
        "name": "PEM 3",
        "part_number": "740-029970",
        "serial_number": "QCS1601U00P",
        "version": "Rev 11"
    },
    {
        "clei_code": "COUCASKBAA",
        "description": "RE-S-1800x4",
        "model_number": "RE-S-1800X4-16G-S",
        "name": "Routing Engine 0",
        "part_number": "740-031116",
        "serial_number": "9009158058",
        "version": "REV 08"
    },
    {
        "clei_code": "COUCASYBAA",
        "description": "RE-S-1800x4",
        "model_number": "RE-S-1800X4-16G-S",
        "name": "Routing Engine 1",
        "part_number": "740-031116",
        "serial_number": "9009211349",
        "version": "REV 10"
    },
    {
        "clei_code": "COUCATYBAA",
        "description": "Enhanced MX SCB 2",
        "model_number": "SCBE2-MX-S",
        "name": "CB 0",
        "part_number": "750-055976",
        "serial_number": "CAFA9891",
        "version": "REV 05"
    },
    {
        "clei_code": "COUCATYBAA",
        "description": "Enhanced MX SCB 2",
        "model_number": "SCBE2-MX-S",
        "name": "CB 1",
        "part_number": "750-055976",
        "serial_number": "CAFA9633",
        "version": "REV 05"
    },
    {
        "chassis_sub_module": [
            {
                "description": "AMPC PMB",
                "name": "CPU",
                "part-number": "711-029089",
                "serial-number": "ABBR3454",
                "version": "REV 12"
            },
            {
                "chassis-sub-sub-module": [
                    {
                        "description": "SFP+-10G-LR",
                        "name": "Xcvr 0",
                        "part-number": "740-031981",
                        "serial-number": "F179JU01240",
                        "version": "REV 01"
                    },
                    {
                        "description": "SFP+-10G-LR",
                        "name": "Xcvr 1",
                        "part-number": "740-031981",
                        "serial-number": "F179JU01254",
                        "version": "REV 01"
                    },
                    {
                        "description": "SFP+-10G-LR",
                        "name": "Xcvr 2",
                        "part-number": "740-031981",
                        "serial-number": "F179JU01237",
                        "version": "REV 01"
                    },
                    {
                        "description": "SFP+-10G-LR",
                        "name": "Xcvr 3",
                        "part-number": "740-031981",
                        "serial-number": "F179JU01257",
                        "version": "REV 01"
                    }
                ],
                "description": "4x 10GE(LAN) SFP+",
                "name": "PIC 0",
                "part-number": "BUILTIN",
                "serial-number": "BUILTIN"
            },
            {
                "chassis-sub-sub-module": [
                    {
                        "description": "SFP+-10G-LR",
                        "name": "Xcvr 0",
                        "part-number": "740-021309",
                        "serial-number": "FS40311M0029",
                        "version": "REV 01"
                    },
                    {
                        "description": "SFP+-10G-LR",
                        "name": "Xcvr 1",
                        "part-number": "740-021309",
                        "serial-number": "C1807080221",
                        "version": "REV 01"
                    }
                ],
                "description": "4x 10GE(LAN) SFP+",
                "name": "PIC 1",
                "part-number": "BUILTIN",
                "serial-number": "BUILTIN"
            },
            {
                "chassis-sub-sub-module": [
                    {
                        "description": "SFP+-10G-CU3M",
                        "name": "Xcvr 0",
                        "part-number": "740-030077",
                        "serial-number": "JNS21I60298",
                        "version": "REV 01"
                    },
                    {
                        "description": "SFP+-10G-CU3M",
                        "name": "Xcvr 1",
                        "part-number": "740-030077",
                        "serial-number": "JNS21I60298",
                        "version": "REV 01"
                    }
                ],
                "description": "4x 10GE(LAN) SFP+",
                "name": "PIC 2",
                "part-number": "BUILTIN",
                "serial-number": "BUILTIN"
            },
            {
                "description": "4x 10GE(LAN) SFP+",
                "name": "PIC 3",
                "part-number": "BUILTIN",
                "serial-number": "BUILTIN"
            }
        ],
        "description": "MPC 3D 16x 10GE",
        "model_number": "MPC-3D-16XGE-SFPP",
        "name": "FPC 2",
        "part_number": "750-028467",
        "serial_number": "ABBS0202",
        "version": "REV 38"
    },
    {
        "chassis_sub_module": [
            {
                "description": "HMPC PMB 2G",
                "name": "CPU",
                "part-number": "711-035209",
                "serial-number": "CACY9250",
                "version": "REV 10"
            },
            {
                "chassis-sub-sub-module": {
                    "chassis-sub-sub-sub-module": [
                        {
                            "description": "SFP+-10G-SR",
                            "name": "Xcvr 0",
                            "part-number": "740-031980",
                            "serial-number": "M0708040319",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-SR",
                            "name": "Xcvr 1",
                            "part-number": "740-031980",
                            "serial-number": "M0708040292",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-SR",
                            "name": "Xcvr 2",
                            "part-number": "740-031980",
                            "serial-number": "M0708040312",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-SR",
                            "name": "Xcvr 3",
                            "part-number": "740-031980",
                            "serial-number": "M0708040295",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-LR",
                            "name": "Xcvr 4",
                            "part-number": "740-021309",
                            "serial-number": "FS40311M0028",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-CU3M",
                            "name": "Xcvr 5",
                            "part-number": "740-030077",
                            "serial-number": "JNS21I60298",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-CU3M",
                            "name": "Xcvr 6",
                            "part-number": "740-030077",
                            "serial-number": "JNS21I60298",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-LR",
                            "name": "Xcvr 9",
                            "part-number": "NON-JNPR",
                            "serial-number": "FS41111M0091",
                            "version": null
                        }
                    ],
                    "description": "10X10GE SFPP",
                    "name": "PIC 0",
                    "part-number": "BUILTIN",
                    "serial-number": "BUILTIN"
                },
                "clei-code": "COUIBD8BAA",
                "description": "10X10GE SFPP",
                "model-number": "MIC3-3D-10XGE-SFPP",
                "name": "MIC 0",
                "part-number": "750-033307",
                "serial-number": "CAGP6185",
                "version": "REV 12"
            },
            {
                "chassis-sub-sub-module": {
                    "chassis-sub-sub-sub-module": [
                        {
                            "description": "QSFP+-40G-LR4",
                            "name": "Xcvr 0",
                            "part-number": "740-043308",
                            "serial-number": "F177JU05515",
                            "version": "REV 01"
                        },
                        {
                            "description": "QSFP+-40G-LR4",
                            "name": "Xcvr 1",
                            "part-number": "740-043308",
                            "serial-number": "F177JU05514",
                            "version": "REV 01"
                        }
                    ],
                    "description": "2X40GE QSFPP",
                    "name": "PIC 2",
                    "part-number": "BUILTIN",
                    "serial-number": "BUILTIN"
                },
                "clei-code": "IPUCBJECAA",
                "description": "2X40GE QSFPP",
                "model-number": "MIC3-3D-2X40GE-QSFPP",
                "name": "MIC 1",
                "part-number": "750-036233",
                "serial-number": "CAEZ4606",
                "version": "REV 12"
            }
        ],
        "clei_code": "COUIBBNBAB",
        "description": "MPCE Type 3 3D",
        "model_number": "MX-MPC3E-3D",
        "name": "FPC 3",
        "part_number": "750-045372",
        "serial_number": "CACY0564",
        "version": "REV 14"
    },
    {
        "description": "Enhanced Left Fan Tray",
        "model_number": "FFANTRAY-MX480-HC-S",
        "name": "Fan Tray"
    }
]
```
AFTER:
```
"ansible_net_modules": [
        {
            "description": "MX480 Midplane",
            "model_number": "CHAS-BP-MX480-S",
            "name": "Midplane",
            "part_number": "710-017414",
            "serial_number": "TR3128",
            "version": "REV 05"
        },
        {
            "description": "Front Panel Display",
            "model_number": "CRAFT-MX480-S",
            "name": "FPM Board",
            "part_number": "710-017254",
            "serial_number": "KE1631",
            "version": "REV 02"
        },
        {
            "description": "PS 1.4-2.52kW; 90-264V AC in",
            "model_number": "PWR-MX480-2520-AC-S",
            "name": "PEM 0",
            "part_number": "740-029970",
            "serial_number": "QCS1601U04F",
            "version": "Rev 11"
        },
        {
            "description": "PS 1.4-2.52kW; 90-264V AC in",
            "model_number": "PWR-MX480-2520-AC-S",
            "name": "PEM 1",
            "part_number": "740-029970",
            "serial_number": "QCS1601U04P",
            "version": "Rev 11"
        },
        {
            "description": "PS 1.4-2.52kW; 90-264V AC in",
            "model_number": "PWR-MX480-2520-AC-S",
            "name": "PEM 2",
            "part_number": "740-029970",
            "serial_number": "QCS1601U0AF",
            "version": "Rev 11"
        },
        {
            "description": "PS 1.4-2.52kW; 90-264V AC in",
            "model_number": "PWR-MX480-2520-AC-S",
            "name": "PEM 3",
            "part_number": "740-029970",
            "serial_number": "QCS1601U00P",
            "version": "Rev 11"
        },
        {
            "clei_code": "COUCASKBAA",
            "description": "RE-S-1800x4",
            "model_number": "RE-S-1800X4-16G-S",
            "name": "Routing Engine 0",
            "part_number": "740-031116",
            "serial_number": "9009158058",
            "version": "REV 08"
        },
        {
            "clei_code": "COUCASYBAA",
            "description": "RE-S-1800x4",
            "model_number": "RE-S-1800X4-16G-S",
            "name": "Routing Engine 1",
            "part_number": "740-031116",
            "serial_number": "9009211349",
            "version": "REV 10"
        },
        {
            "clei_code": "COUCATYBAA",
            "description": "Enhanced MX SCB 2",
            "model_number": "SCBE2-MX-S",
            "name": "CB 0",
            "part_number": "750-055976",
            "serial_number": "CAFA9891",
            "version": "REV 05"
        },
        {
            "clei_code": "COUCATYBAA",
            "description": "Enhanced MX SCB 2",
            "model_number": "SCBE2-MX-S",
            "name": "CB 1",
            "part_number": "750-055976",
            "serial_number": "CAFA9633",
            "version": "REV 05"
        },
        {
            "chassis_sub_module": [
                {
                    "description": "AMPC PMB",
                    "name": "CPU",
                    "part_number": "711-029089",
                    "serial_number": "ABBR3454",
                    "version": "REV 12"
                },
                {
                    "chassis_sub_sub_module": [
                        {
                            "description": "SFP+-10G-LR",
                            "name": "Xcvr 0",
                            "part_number": "740-031981",
                            "serial_number": "F179JU01240",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-LR",
                            "name": "Xcvr 1",
                            "part_number": "740-031981",
                            "serial_number": "F179JU01254",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-LR",
                            "name": "Xcvr 2",
                            "part_number": "740-031981",
                            "serial_number": "F179JU01237",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-LR",
                            "name": "Xcvr 3",
                            "part_number": "740-031981",
                            "serial_number": "F179JU01257",
                            "version": "REV 01"
                        }
                    ],
                    "description": "4x 10GE(LAN) SFP+",
                    "name": "PIC 0",
                    "part_number": "BUILTIN",
                    "serial_number": "BUILTIN"
                },
                {
                    "chassis_sub_sub_module": [
                        {
                            "description": "SFP+-10G-LR",
                            "name": "Xcvr 0",
                            "part_number": "740-021309",
                            "serial_number": "FS40311M0029",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-LR",
                            "name": "Xcvr 1",
                            "part_number": "740-021309",
                            "serial_number": "C1807080221",
                            "version": "REV 01"
                        }
                    ],
                    "description": "4x 10GE(LAN) SFP+",
                    "name": "PIC 1",
                    "part_number": "BUILTIN",
                    "serial_number": "BUILTIN"
                },
                {
                    "chassis_sub_sub_module": [
                        {
                            "description": "SFP+-10G-CU3M",
                            "name": "Xcvr 0",
                            "part_number": "740-030077",
                            "serial_number": "JNS21I60298",
                            "version": "REV 01"
                        },
                        {
                            "description": "SFP+-10G-CU3M",
                            "name": "Xcvr 1",
                            "part_number": "740-030077",
                            "serial_number": "JNS21I60298",
                            "version": "REV 01"
                        }
                    ],
                    "description": "4x 10GE(LAN) SFP+",
                    "name": "PIC 2",
                    "part_number": "BUILTIN",
                    "serial_number": "BUILTIN"
                },
                {
                    "description": "4x 10GE(LAN) SFP+",
                    "name": "PIC 3",
                    "part_number": "BUILTIN",
                    "serial_number": "BUILTIN"
                }
            ],
            "description": "MPC 3D 16x 10GE",
            "model_number": "MPC-3D-16XGE-SFPP",
            "name": "FPC 2",
            "part_number": "750-028467",
            "serial_number": "ABBS0202",
            "version": "REV 38"
        },
        {
            "chassis_sub_module": [
                {
                    "description": "HMPC PMB 2G",
                    "name": "CPU",
                    "part_number": "711-035209",
                    "serial_number": "CACY9250",
                    "version": "REV 10"
                },
                {
                    "chassis_sub_sub_module": {
                        "chassis_sub_sub_sub_module": [
                            {
                                "description": "SFP+-10G-SR",
                                "name": "Xcvr 0",
                                "part_number": "740-031980",
                                "serial_number": "M0708040319",
                                "version": "REV 01"
                            },
                            {
                                "description": "SFP+-10G-SR",
                                "name": "Xcvr 1",
                                "part_number": "740-031980",
                                "serial_number": "M0708040292",
                                "version": "REV 01"
                            },
                            {
                                "description": "SFP+-10G-SR",
                                "name": "Xcvr 2",
                                "part_number": "740-031980",
                                "serial_number": "M0708040312",
                                "version": "REV 01"
                            },
                            {
                                "description": "SFP+-10G-SR",
                                "name": "Xcvr 3",
                                "part_number": "740-031980",
                                "serial_number": "M0708040295",
                                "version": "REV 01"
                            },
                            {
                                "description": "SFP+-10G-LR",
                                "name": "Xcvr 4",
                                "part_number": "740-021309",
                                "serial_number": "FS40311M0028",
                                "version": "REV 01"
                            },
                            {
                                "description": "SFP+-10G-CU3M",
                                "name": "Xcvr 5",
                                "part_number": "740-030077",
                                "serial_number": "JNS21I60298",
                                "version": "REV 01"
                            },
                            {
                                "description": "SFP+-10G-CU3M",
                                "name": "Xcvr 6",
                                "part_number": "740-030077",
                                "serial_number": "JNS21I60298",
                                "version": "REV 01"
                            },
                            {
                                "description": "SFP+-10G-LR",
                                "name": "Xcvr 9",
                                "part_number": "NON-JNPR",
                                "serial_number": "FS41111M0091",
                                "version": null
                            }
                        ],
                        "description": "10X10GE SFPP",
                        "name": "PIC 0",
                        "part_number": "BUILTIN",
                        "serial_number": "BUILTIN"
                    },
                    "clei_code": "COUIBD8BAA",
                    "description": "10X10GE SFPP",
                    "model_number": "MIC3-3D-10XGE-SFPP",
                    "name": "MIC 0",
                    "part_number": "750-033307",
                    "serial_number": "CAGP6185",
                    "version": "REV 12"
                },
                {
                    "chassis_sub_sub_module": {
                        "chassis_sub_sub_sub_module": [
                            {
                                "description": "QSFP+-40G-LR4",
                                "name": "Xcvr 0",
                                "part_number": "740-043308",
                                "serial_number": "F177JU05515",
                                "version": "REV 01"
                            },
                            {
                                "description": "QSFP+-40G-LR4",
                                "name": "Xcvr 1",
                                "part_number": "740-043308",
                                "serial_number": "F177JU05514",
                                "version": "REV 01"
                            }
                        ],
                        "description": "2X40GE QSFPP",
                        "name": "PIC 2",
                        "part_number": "BUILTIN",
                        "serial_number": "BUILTIN"
                    },
                    "clei_code": "IPUCBJECAA",
                    "description": "2X40GE QSFPP",
                    "model_number": "MIC3-3D-2X40GE-QSFPP",
                    "name": "MIC 1",
                    "part_number": "750-036233",
                    "serial_number": "CAEZ4606",
                    "version": "REV 12"
                }
            ],
            "clei_code": "COUIBBNBAB",
            "description": "MPCE Type 3 3D",
            "model_number": "MX-MPC3E-3D",
            "name": "FPC 3",
            "part_number": "750-045372",
            "serial_number": "CACY0564",
            "version": "REV 14"
        },
        {
            "description": "Enhanced Left Fan Tray",
            "model_number": "FFANTRAY-MX480-HC-S",
            "name": "Fan Tray"
        }
    ]
```
