### PR TITLE
Add Overridden operation support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 ---
 name: release
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   release:
     types: [published]
 

--- a/changelogs/fragments/ospf_interfaces_auth_fixes.yaml
+++ b/changelogs/fragments/ospf_interfaces_auth_fixes.yaml
@@ -1,3 +1,9 @@
 ---
 bugfixes:
-  - fix md5 authentication which allows list of keys to be configured. 
+  - fix md5 authentication which allows list of keys to be configured.
+  - fix `node_link_protection` implementation.
+  - fix `no_advertise_adjacency_segment` config implementation.
+  - fix `no_neighbor_down_notification` config implementation.
+  - fix `no_interface_state_traps` config implementation.
+  - fix `no_eligible_remote_backup` config implementation.
+  - fix `no_eligible_backup` config implementation.

--- a/changelogs/fragments/ospf_interfaces_auth_fixes.yaml
+++ b/changelogs/fragments/ospf_interfaces_auth_fixes.yaml
@@ -1,9 +1,0 @@
----
-bugfixes:
-  - fix md5 authentication which allows list of keys to be configured.
-  - fix `node_link_protection` implementation.
-  - fix `no_advertise_adjacency_segment` config implementation.
-  - fix `no_neighbor_down_notification` config implementation.
-  - fix `no_interface_state_traps` config implementation.
-  - fix `no_eligible_remote_backup` config implementation.
-  - fix `no_eligible_backup` config implementation.

--- a/changelogs/fragments/ospf_interfaces_auth_fixes.yaml
+++ b/changelogs/fragments/ospf_interfaces_auth_fixes.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - fix md5 authentication which allows list of keys to be configured. 

--- a/changelogs/fragments/overridden_support.yaml
+++ b/changelogs/fragments/overridden_support.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - add overridden state opperation support.

--- a/changelogs/fragments/overridden_support.yaml
+++ b/changelogs/fragments/overridden_support.yaml
@@ -1,3 +1,11 @@
 ---
 minor_changes:
   - add overridden state opperation support.
+bugfixes:
+  - fix md5 authentication which allows list of keys to be configured.
+  - fix `node_link_protection` implementation.
+  - fix `no_advertise_adjacency_segment` config implementation.
+  - fix `no_neighbor_down_notification` config implementation.
+  - fix `no_interface_state_traps` config implementation.
+  - fix `no_eligible_remote_backup` config implementation.
+  - fix `no_eligible_backup` config implementation.

--- a/docs/junipernetworks.junos.junos_bgp_global_module.rst
+++ b/docs/junipernetworks.junos.junos_bgp_global_module.rst
@@ -10548,6 +10548,7 @@ Parameters
                                     <li>purged</li>
                                     <li><div style="color: blue"><b>merged</b>&nbsp;&larr;</div></li>
                                     <li>replaced</li>
+                                    <li>overridden</li>
                                     <li>deleted</li>
                                     <li>gathered</li>
                                     <li>parsed</li>
@@ -10743,6 +10744,145 @@ Examples
          out_delay: 10
          preference: "2"
        state: replaced
+
+    # Task Output:
+    # ------------
+    #
+    # before:
+    #   accept_remote_nexthop: true
+    #   add_path_display_ipv4_address: true
+    #   advertise_from_main_vpn_tables: true
+    #   advertise_inactive: true
+    #   as_number: '65534'
+    #   asdot_notation: true
+    #   authentication_algorithm: md5
+    #   bgp_error_tolerance:
+    #     malformed_route_limit: 20000000
+    #   bmp:
+    #     monitor: true
+    #   damping: true
+    #   description: This is configured with Junos_bgp resource module
+    #   egress_te_sid_stats: true
+    #   hold_time: 5
+    #   holddown_all_stale_labels: true
+    #   include_mp_next_hop: true
+    #   log_updown: true
+    #   loops: 3
+    #   no_advertise_peer_as: true
+    #   no_aggregator_id: true
+    #   no_client_reflect: true
+    #   out_delay: 10
+    #   precision_timers: true
+    #   preference: '2'
+
+    # commands:
+    # - <nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:bgp>
+    #   <nc:accept-remote-nexthop delete="delete"/><nc:add-path-display-ipv4-address delete="delete"/><nc:advertise-bgp-t
+    #   delete="delete"/><nc:include-mp-next-hop delete="delete"/><nc:ipsec-sa delete="delete"/><nc:keep delete="delete"/>
+    #   <nc:local-address delete="delete"/><nc:local-interface delete="delete"/t
+    #   delete="delete"/></nc:bgp><nc:bgp><nc:advertise-inactive/><nc:egress-te-sid-stats/>
+    #   <nc:authentication-algorithm>md5</nc:authentication-algorithm><nc:description>Replace running bgp conf>
+    # - <nc:routing-options xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:autonomous-system delete="delete"/></nc:routing-options>
+
+    #
+    # after:
+    #   advertise_inactive: true
+    #   authentication_algorithm: md5
+    #   bfd_liveness_detection:
+    #     minimum_receive_interval: 8
+    #     multiplier: 30
+    #     no_adaptation: true
+    #     transmit_interval:
+    #       minimum_interval: 4
+    #     version: automatic
+    #   bgp_error_tolerance:
+    #     malformed_route_limit: 40000000
+    #   description: Replace running bgp config
+    #   egress_te_sid_stats: true
+    #   hold_time: 5
+    #   out_delay: 10
+    #   preference: '2'
+
+    # After state:
+    # ------------
+    #
+    # varx# show protocols bgp
+    # description "Replace running bgp config";
+    # preference 2;
+    # hold-time 5;
+    # advertise-inactive;
+    # out-delay 10;
+    # bgp-error-tolerance {
+    #     malformed-route-limit 40000000;
+    # }
+    # authentication-algorithm md5;
+    # bfd-liveness-detection {
+    #     version automatic;
+    #     minimum-receive-interval 8;
+    #     multiplier 30;
+    #     no-adaptation;
+    #     transmit-interval {
+    #         minimum-interval 4;
+    #     }
+    # }
+    # egress-te-sid-stats;
+
+    # vsrx# show routing-options autonomous-system
+
+    # Using overridden
+    # "(NOTE: This will work same as replaced operation)"
+    #
+    # Before state:
+    # -------------
+    #
+    # vsrx# show routing-options autonomous-system
+    # [edit]
+    # vsrx# show protocols bgp
+    # precision-timers;
+    # advertise-from-main-vpn-tables;
+    # holddown-all-stale-labels;
+    # description "This is configured with Junos_bgp resource module";
+    # accept-remote-nexthop;
+    # preference 2;
+    # hold-time 5;
+    # advertise-inactive;
+    # no-advertise-peer-as;
+    # no-aggregator-id;
+    # out-delay 10;
+    # log-updown;
+    # damping;
+    # bgp-error-tolerance {
+    #     malformed-route-limit 20000000;
+    # }
+    # authentication-algorithm md5;
+    # no-client-reflect;
+    # include-mp-next-hop;
+    # bmp {
+    #     monitor enable;
+    # }
+    # add-path-display-ipv4-address;
+    # egress-te-sid-stats;
+
+    - name: Override running config with provided config
+      junipernetworks.junos.junos_bgp_global:
+       config:
+         advertise_inactive: true
+         authentication_algorithm: "md5"
+         bfd_liveness_detection:
+           minimum_receive_interval: 8
+           multiplier: 30
+           no_adaptation: true
+           transmit_interval:
+             minimum_interval: 4
+           version: "automatic"
+         bgp_error_tolerance:
+           malformed_route_limit: 40000000
+         description: "Replace running bgp config"
+         egress_te_sid_stats: true
+         hold_time: 5
+         out_delay: 10
+         preference: "2"
+       state: overridden
 
     # Task Output:
     # ------------

--- a/docs/junipernetworks.junos.junos_ospf_interfaces_module.rst
+++ b/docs/junipernetworks.junos.junos_ospf_interfaces_module.rst
@@ -178,7 +178,8 @@ Parameters
                     <b>md5</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">dictionary</span>
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
                     </div>
                 </td>
                 <td>
@@ -198,7 +199,7 @@ Parameters
                     <b>key_id</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">string</span>
+                        <span style="color: purple">integer</span>
                     </div>
                 </td>
                 <td>
@@ -606,10 +607,14 @@ Parameters
                     <b>node_link_protection</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
-                        <span style="color: purple">string</span>
+                        <span style="color: purple">boolean</span>
                     </div>
                 </td>
                 <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
                 </td>
                 <td>
                         <div>Protect interface from both link and node faults.</div>

--- a/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/junos/argspec/bgp_global/bgp_global.py
@@ -1260,6 +1260,7 @@ class Bgp_globalArgs(object):  # pylint: disable=R0903
                 "purged",
                 "merged",
                 "replaced",
+                "overridden",
                 "deleted",
                 "gathered",
                 "parsed",

--- a/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
@@ -58,6 +58,7 @@ class Ospf_interfacesArgs(object):  # pylint: disable=R0903
                                 "authentication": {
                                     "options": {
                                         "md5": {
+                                            "elements": "dict",
                                             "options": {
                                                 "key_id": {"type": "str"},
                                                 "key_value": {
@@ -66,7 +67,7 @@ class Ospf_interfacesArgs(object):  # pylint: disable=R0903
                                                 },
                                                 "start_time": {"type": "str"},
                                             },
-                                            "type": "dict",
+                                            "type": "list",
                                         },
                                         "simple_password": {
                                             "type": "str",

--- a/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/argspec/ospf_interfaces/ospf_interfaces.py
@@ -60,7 +60,7 @@ class Ospf_interfacesArgs(object):  # pylint: disable=R0903
                                         "md5": {
                                             "elements": "dict",
                                             "options": {
-                                                "key_id": {"type": "str"},
+                                                "key_id": {"type": "int"},
                                                 "key_value": {
                                                     "type": "str",
                                                     "no_log": True,
@@ -107,7 +107,7 @@ class Ospf_interfacesArgs(object):  # pylint: disable=R0903
                                 "no_neighbor_down_notification": {
                                     "type": "bool",
                                 },
-                                "node_link_protection": {"type": "str"},
+                                "node_link_protection": {"type": "bool"},
                                 "poll_interval": {"type": "int"},
                                 "priority": {"type": "int"},
                                 "passive": {"type": "bool"},

--- a/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
+++ b/plugins/module_utils/network/junos/config/bgp_global/bgp_global.py
@@ -168,7 +168,7 @@ class Bgp_global(ConfigBase):
             config_xmls = self._state_purged(want, have)
         elif state in ("merged", "rendered"):
             config_xmls = self._state_merged(want, have)
-        elif state == "replaced":
+        elif state in ("replaced", "overridden"):
             config_xmls = self._state_replaced(want, have)
 
         if config_xmls:

--- a/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
@@ -179,7 +179,6 @@ class Ospf_interfaces(ConfigBase):
 
         for xml in config_xmls:
             self.protocols.append(xml)
-
         return [tostring(xml) for xml in self.root.getchildren()]
 
     def _state_replaced(self, want, have):
@@ -293,6 +292,36 @@ class Ospf_interfaces(ConfigBase):
                         existing_config = have[0]
                         if existing_config["name"] == ospf_interfaces["name"]:
                             intf_node.attrib.update(delete)
+
+                if "authentication" in processes:
+                    auth = processes.get("authentication")
+                    auth_node = build_child_xml_node(intf_node, "authentication")
+                    if "simple_password" in auth:
+                        build_child_xml_node(
+                            auth_node,
+                            "simple-password",
+                            auth.get("simple_password"),
+                        )
+                    if "md5" in auth:
+                        md5_lst = auth.get("md5")
+                        for md5 in md5_lst:
+                            md5_node = build_child_xml_node(auth_node, "md5")
+                            build_child_xml_node(
+                                md5_node,
+                                "name",
+                                md5.get("key_id"),
+                            )
+                            build_child_xml_node(
+                                md5_node,
+                                "key",
+                                md5.get("key_value"),
+                            )
+                            if "start_time" in md5:
+                                build_child_xml_node(
+                                    md5_node,
+                                    "start-time",
+                                    md5.get("start_time"),
+                                )
                 if processes.get("priority"):
                     build_child_xml_node(
                         intf_node,
@@ -357,6 +386,49 @@ class Ospf_interfaces(ConfigBase):
                         "retransmit-interval",
                         processes.get("retransmit_interval"),
                     )
+                if "node_link_protection" in  processes:
+                    if processes.get("node_link_protection"):
+                        build_child_xml_node(
+                            intf_node,
+                            "node-link-protection",
+                        )
+                if "no_advertise_adjacency_segment" in  processes:
+                    if processes.get("no_advertise_adjacency_segment"):
+                        build_child_xml_node(
+                            intf_node,
+                            "no-advertise-adjacency-segment",
+                        )
+                if "no_neighbor_down_notification" in  processes:
+                    if processes.get("no_neighbor_down_notification"):
+                        build_child_xml_node(
+                            intf_node,
+                            "no-neighbor-down-notification",
+                        )
+                if "no_interface_state_traps" in  processes:
+                    if processes.get("no_interface_state_traps"):
+                        build_child_xml_node(
+                            intf_node,
+                            "no-interface-state-traps",
+                        )
+                if "no_eligible_remote_backup" in  processes:
+                    if processes.get("no_eligible_remote_backup"):
+                        build_child_xml_node(
+                            intf_node,
+                            "no-eligible-remote-backup",
+                        )
+                if "no_eligible_backup" in  processes:
+                    if processes.get("no_eligible_backup"):
+                        build_child_xml_node(
+                            intf_node,
+                            "no-eligible-backup",
+                        )
+                if "demand_circuit" in  processes:
+                    if processes.get("demand_circuit"):
+                        build_child_xml_node(
+                            intf_node,
+                            "demand-circuit",
+                        )
+
 
         ospf_interfaces_xml.append(protocol)
         return ospf_interfaces_xml

--- a/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
@@ -386,49 +386,48 @@ class Ospf_interfaces(ConfigBase):
                         "retransmit-interval",
                         processes.get("retransmit_interval"),
                     )
-                if "node_link_protection" in  processes:
+                if "node_link_protection" in processes:
                     if processes.get("node_link_protection"):
                         build_child_xml_node(
                             intf_node,
                             "node-link-protection",
                         )
-                if "no_advertise_adjacency_segment" in  processes:
+                if "no_advertise_adjacency_segment" in processes:
                     if processes.get("no_advertise_adjacency_segment"):
                         build_child_xml_node(
                             intf_node,
                             "no-advertise-adjacency-segment",
                         )
-                if "no_neighbor_down_notification" in  processes:
+                if "no_neighbor_down_notification" in processes:
                     if processes.get("no_neighbor_down_notification"):
                         build_child_xml_node(
                             intf_node,
                             "no-neighbor-down-notification",
                         )
-                if "no_interface_state_traps" in  processes:
+                if "no_interface_state_traps" in processes:
                     if processes.get("no_interface_state_traps"):
                         build_child_xml_node(
                             intf_node,
                             "no-interface-state-traps",
                         )
-                if "no_eligible_remote_backup" in  processes:
+                if "no_eligible_remote_backup" in processes:
                     if processes.get("no_eligible_remote_backup"):
                         build_child_xml_node(
                             intf_node,
                             "no-eligible-remote-backup",
                         )
-                if "no_eligible_backup" in  processes:
+                if "no_eligible_backup" in processes:
                     if processes.get("no_eligible_backup"):
                         build_child_xml_node(
                             intf_node,
                             "no-eligible-backup",
                         )
-                if "demand_circuit" in  processes:
+                if "demand_circuit" in processes:
                     if processes.get("demand_circuit"):
                         build_child_xml_node(
                             intf_node,
                             "demand-circuit",
                         )
-
 
         ospf_interfaces_xml.append(protocol)
         return ospf_interfaces_xml

--- a/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
@@ -235,16 +235,16 @@ class Ospf_interfacesFacts(object):
                             md5_lst = []
                             if isinstance(md5_cfg, dict):
                                 md5_dict = {}
-                                md5_dict['key_id'] = md5_cfg.get("name")
-                                md5_dict['key_value'] = md5_cfg.get("key")
-                                md5_dict['start_time'] = md5_cfg.get("start-time")
+                                md5_dict["key_id"] = md5_cfg.get("name")
+                                md5_dict["key_value"] = md5_cfg.get("key")
+                                md5_dict["start_time"] = md5_cfg.get("start-time")
                                 md5_lst.append(md5_dict)
                             else:
                                 for md5 in md5_cfg:
                                     md5_dict = {}
-                                    md5_dict['key_id'] = md5.get("name")
-                                    md5_dict['key_value'] = md5.get("key")
-                                    md5_dict['start_time'] = md5.get("start-time")
+                                    md5_dict["key_id"] = md5.get("name")
+                                    md5_dict["key_value"] = md5.get("key")
+                                    md5_dict["start_time"] = md5.get("start-time")
                                     md5_lst.append(md5_dict)
                             auth_dict["md5"] = md5_lst
                         interface_dict["authentication"] = auth_dict

--- a/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
@@ -112,7 +112,7 @@ class Ospf_interfacesFacts(object):
 
         objs = []
         for resource in resources:
-            if resource:
+            if resource is not None:
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 

--- a/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
@@ -230,20 +230,23 @@ class Ospf_interfacesFacts(object):
                             auth_dict["simple_password"] = auth.get(
                                 "simple-password",
                             )
-                        elif auth.get("md5"):
-                            auth_dict["type"] = {"md5": []}
-                            md5_list = auth.get("md5")
-
-                            if not isinstance(md5_list, list):
-                                md5_list = [md5_list]
-
-                            for md5_auth in md5_list:
-                                auth_dict["type"]["md5"].append(
-                                    {
-                                        "key_id": md5_auth.get("name"),
-                                        "key": md5_auth.get("key"),
-                                    },
-                                )
+                        if "md5" in auth.keys():
+                            md5_cfg = auth.get("md5")
+                            md5_lst = []
+                            if isinstance(md5_cfg, dict):
+                                md5_dict = {}
+                                md5_dict['key_id'] = md5_cfg.get("name")
+                                md5_dict['key_value'] = md5_cfg.get("key")
+                                md5_dict['start_time'] = md5_cfg.get("start-time")
+                                md5_lst.append(md5_dict)
+                            else:
+                                for md5 in md5_cfg:
+                                    md5_dict = {}
+                                    md5_dict['key_id'] = md5.get("name")
+                                    md5_dict['key_value'] = md5.get("key")
+                                    md5_dict['start_time'] = md5.get("start-time")
+                                    md5_lst.append(md5_dict)
+                            auth_dict["md5"] = md5_lst
                         interface_dict["authentication"] = auth_dict
 
                     rendered_area["interfaces"].append(interface_dict)

--- a/plugins/modules/junos_bgp_global.py
+++ b/plugins/modules/junos_bgp_global.py
@@ -947,6 +947,7 @@ options:
       - purged
       - merged
       - replaced
+      - overridden
       - deleted
       - gathered
       - parsed
@@ -1116,6 +1117,145 @@ EXAMPLES = """
      out_delay: 10
      preference: "2"
    state: replaced
+
+# Task Output:
+# ------------
+#
+# before:
+#   accept_remote_nexthop: true
+#   add_path_display_ipv4_address: true
+#   advertise_from_main_vpn_tables: true
+#   advertise_inactive: true
+#   as_number: '65534'
+#   asdot_notation: true
+#   authentication_algorithm: md5
+#   bgp_error_tolerance:
+#     malformed_route_limit: 20000000
+#   bmp:
+#     monitor: true
+#   damping: true
+#   description: This is configured with Junos_bgp resource module
+#   egress_te_sid_stats: true
+#   hold_time: 5
+#   holddown_all_stale_labels: true
+#   include_mp_next_hop: true
+#   log_updown: true
+#   loops: 3
+#   no_advertise_peer_as: true
+#   no_aggregator_id: true
+#   no_client_reflect: true
+#   out_delay: 10
+#   precision_timers: true
+#   preference: '2'
+
+# commands:
+# - <nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:bgp>
+#   <nc:accept-remote-nexthop delete="delete"/><nc:add-path-display-ipv4-address delete="delete"/><nc:advertise-bgp-t
+#   delete="delete"/><nc:include-mp-next-hop delete="delete"/><nc:ipsec-sa delete="delete"/><nc:keep delete="delete"/>
+#   <nc:local-address delete="delete"/><nc:local-interface delete="delete"/t
+#   delete="delete"/></nc:bgp><nc:bgp><nc:advertise-inactive/><nc:egress-te-sid-stats/>
+#   <nc:authentication-algorithm>md5</nc:authentication-algorithm><nc:description>Replace running bgp conf>
+# - <nc:routing-options xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:autonomous-system delete="delete"/></nc:routing-options>
+
+#
+# after:
+#   advertise_inactive: true
+#   authentication_algorithm: md5
+#   bfd_liveness_detection:
+#     minimum_receive_interval: 8
+#     multiplier: 30
+#     no_adaptation: true
+#     transmit_interval:
+#       minimum_interval: 4
+#     version: automatic
+#   bgp_error_tolerance:
+#     malformed_route_limit: 40000000
+#   description: Replace running bgp config
+#   egress_te_sid_stats: true
+#   hold_time: 5
+#   out_delay: 10
+#   preference: '2'
+
+# After state:
+# ------------
+#
+# varx# show protocols bgp
+# description "Replace running bgp config";
+# preference 2;
+# hold-time 5;
+# advertise-inactive;
+# out-delay 10;
+# bgp-error-tolerance {
+#     malformed-route-limit 40000000;
+# }
+# authentication-algorithm md5;
+# bfd-liveness-detection {
+#     version automatic;
+#     minimum-receive-interval 8;
+#     multiplier 30;
+#     no-adaptation;
+#     transmit-interval {
+#         minimum-interval 4;
+#     }
+# }
+# egress-te-sid-stats;
+
+# vsrx# show routing-options autonomous-system
+
+# Using overridden
+# "(NOTE: This will work same as replaced operation)"
+#
+# Before state:
+# -------------
+#
+# vsrx# show routing-options autonomous-system
+# [edit]
+# vsrx# show protocols bgp
+# precision-timers;
+# advertise-from-main-vpn-tables;
+# holddown-all-stale-labels;
+# description "This is configured with Junos_bgp resource module";
+# accept-remote-nexthop;
+# preference 2;
+# hold-time 5;
+# advertise-inactive;
+# no-advertise-peer-as;
+# no-aggregator-id;
+# out-delay 10;
+# log-updown;
+# damping;
+# bgp-error-tolerance {
+#     malformed-route-limit 20000000;
+# }
+# authentication-algorithm md5;
+# no-client-reflect;
+# include-mp-next-hop;
+# bmp {
+#     monitor enable;
+# }
+# add-path-display-ipv4-address;
+# egress-te-sid-stats;
+
+- name: Override running config with provided config
+  junipernetworks.junos.junos_bgp_global:
+   config:
+     advertise_inactive: true
+     authentication_algorithm: "md5"
+     bfd_liveness_detection:
+       minimum_receive_interval: 8
+       multiplier: 30
+       no_adaptation: true
+       transmit_interval:
+         minimum_interval: 4
+       version: "automatic"
+     bgp_error_tolerance:
+       malformed_route_limit: 40000000
+     description: "Replace running bgp config"
+     egress_te_sid_stats: true
+     hold_time: 5
+     out_delay: 10
+     preference: "2"
+   state: overridden
 
 # Task Output:
 # ------------
@@ -1708,6 +1848,7 @@ def main():
     required_if = [
         ("state", "merged", ("config",)),
         ("state", "replaced", ("config",)),
+        ("state", "overridden", ("config",)),
         ("state", "rendered", ("config",)),
         ("state", "parsed", ("running_config",)),
     ]

--- a/plugins/modules/junos_ospf_interfaces.py
+++ b/plugins/modules/junos_ospf_interfaces.py
@@ -102,7 +102,8 @@ options:
                   md5:
                     description:
                       - Specify md5 based authentication.
-                    type: dict
+                    type: list
+                    elements: dict
                     suboptions:
                       key_id:
                         description: Specify md5 key-id

--- a/plugins/modules/junos_ospf_interfaces.py
+++ b/plugins/modules/junos_ospf_interfaces.py
@@ -107,7 +107,7 @@ options:
                     suboptions:
                       key_id:
                         description: Specify md5 key-id
-                        type: str
+                        type: int
                       key_value:
                         description: Specify key value
                         type: str
@@ -190,7 +190,7 @@ options:
               node_link_protection:
                 description:
                   - Protect interface from both link and node faults.
-                type: str
+                type: bool
               dead_interval:
                 description:
                   - Dead interval (seconds).

--- a/tests/integration/targets/junos_bgp_global/tests/netconf/overridden.yaml
+++ b/tests/integration/targets/junos_bgp_global/tests/netconf/overridden.yaml
@@ -1,0 +1,51 @@
+---
+- name: Debug task
+  ansible.builtin.debug:
+    msg: "START junos_bgp_global overridden integration tests on connection={{ ansible_connection }}"
+
+- block:
+    - name: Reset configuration
+      ansible.builtin.include_tasks: _reset_config.yaml
+
+    - name: Initial config
+      ansible.builtin.include_tasks: _initial_config.yaml
+
+    - name: Replace configuration
+      junipernetworks.junos.junos_bgp_global: &overridden
+        config:
+          bgp_error_tolerance:
+            malformed_route_limit: 20000000
+          bmp:
+            monitor: true
+          damping: true
+          description: "This is configured with Junos_bgp resource module"
+        state: overridden
+      register: result
+
+    - name: Assert that before dicts were correctly generated
+      ansible.builtin.assert:
+        that: "{{ merged['after'] == result['before'] }}"
+
+    - name: Assert configuration
+      ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - "{{ overridden['after'] == result.after }}"
+
+    - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
+      junipernetworks.junos.junos_bgp_global: *overridden
+      register: result
+
+    - name: Assert that the previous task was idempotent
+      ansible.builtin.assert:
+        that:
+          - result.changed == False
+
+  tags: overridden
+  always:
+    - name: Reset configuration
+      ansible.builtin.include_tasks: _reset_config.yaml
+
+- name: Debug task
+  ansible.builtin.debug:
+    msg: "END junos_bgp_global overridden integration tests on connection={{ ansible_connection }}"

--- a/tests/integration/targets/junos_ospf_interfaces/tests/netconf/merged.yaml
+++ b/tests/integration/targets/junos_ospf_interfaces/tests/netconf/merged.yaml
@@ -7,152 +7,152 @@
 
     - ansible.builtin.set_fact:
         expected_config:
-        - address_family:
-          - afi: "ipv4"
-            processes:
-              area:
-                area_id: "0.0.0.100"
-              authentication:
-                md5:
-                - key_id: 56
-                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-                  start_time: "2023-7-1.02:00:00 +0000"
-                - key_id: 50
-                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-                - key_id: 40
-                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-              bandwidth_based_metrics:
-              - bandwidth: "1g"
-                metric: 5
-              - bandwidth: "10g"
-                metric: 40
-              dead_interval: 4
-              demand_circuit: true
-              hello_interval: 2
-              metric: 5
-              no_advertise_adjacency_segment: true
-              no_eligible_backup: true
-              no_eligible_remote_backup: true
-              no_interface_state_traps: true
-              no_neighbor_down_notification: true
-              node_link_protection: true
-              passive: true
-              poll_interval: 2
-              priority: 3
-              retransmit_interval: 2
-          name: "so-0/0/0.0"
-          router_id: "10.200.16.75"
-        - address_family:
-          - afi: "ipv4"
-            processes:
-              area:
-                area_id: "0.0.0.200"
-              authentication:
-                simple_password: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-              priority: 3
-          name: "so-0/1/0.0"
-          router_id: "10.200.16.75"
-        - address_family:
-          - afi: "ipv4"
-            processes:
-              area:
-                area_id: "0.0.0.200"
-              authentication:
-                md5:
-                - key_id: 10
-                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-                  start_time: "2023-7-12.03:00:00 +0000"
-              priority: 2
-          name: "so-0/2/0.0"
-          router_id: "10.200.16.75"
-        - address_family:
-          - afi: "ipv4"
-            processes:
-              area:
-                area_id: "0.0.0.120"
-              authentication:
-                md5:
-                - key_id: 10
-                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
-                  start_time: "2023-7-12.03:00:00 +0000"
-              priority: 2
-          name: so-0/2/0.1
-          router_id: "10.200.16.75"
+          - address_family:
+              - afi: "ipv4"
+                processes:
+                  area:
+                    area_id: "0.0.0.100"
+                  authentication:
+                    md5:
+                      - key_id: 56
+                        key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                        start_time: "2023-7-1.02:00:00 +0000"
+                      - key_id: 50
+                        key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                      - key_id: 40
+                        key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                  bandwidth_based_metrics:
+                    - bandwidth: "1g"
+                      metric: 5
+                    - bandwidth: "10g"
+                      metric: 40
+                  dead_interval: 4
+                  demand_circuit: true
+                  hello_interval: 2
+                  metric: 5
+                  no_advertise_adjacency_segment: true
+                  no_eligible_backup: true
+                  no_eligible_remote_backup: true
+                  no_interface_state_traps: true
+                  no_neighbor_down_notification: true
+                  node_link_protection: true
+                  passive: true
+                  poll_interval: 2
+                  priority: 3
+                  retransmit_interval: 2
+            name: "so-0/0/0.0"
+            router_id: "10.200.16.75"
+          - address_family:
+              - afi: "ipv4"
+                processes:
+                  area:
+                    area_id: "0.0.0.200"
+                  authentication:
+                    simple_password: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                  priority: 3
+            name: "so-0/1/0.0"
+            router_id: "10.200.16.75"
+          - address_family:
+              - afi: "ipv4"
+                processes:
+                  area:
+                    area_id: "0.0.0.200"
+                  authentication:
+                    md5:
+                      - key_id: 10
+                        key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                        start_time: "2023-7-12.03:00:00 +0000"
+                  priority: 2
+            name: "so-0/2/0.0"
+            router_id: "10.200.16.75"
+          - address_family:
+              - afi: "ipv4"
+                processes:
+                  area:
+                    area_id: "0.0.0.120"
+                  authentication:
+                    md5:
+                      - key_id: 10
+                        key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                        start_time: "2023-7-12.03:00:00 +0000"
+                  priority: 2
+            name: so-0/2/0.1
+            router_id: "10.200.16.75"
 
     - name: Merge the provided configuration with the exisiting running configuration
       junipernetworks.junos.junos_ospf_interfaces: &merged
         config:
-        - address_family:
-          - afi: ipv4
-            processes:
-              area:
-                area_id: 0.0.0.100
-              authentication:
-                md5:
-                - key_id: '56'
-                  key_value: ansible56
-                  start_time: 2023-7-1.02:00:00 +0000
-                - key_id: '50'
-                  key_value: ansible50
-                - key_id: '40'
-                  key_value: ansible40
-              bandwidth_based_metrics:
-              - bandwidth: 1g
-                metric: 5
-              - bandwidth: 10g
-                metric: 40
-              dead_interval: 4
-              hello_interval: 2
-              metric: 5
-              passive: true
-              poll_interval: 2
-              priority: 3
-              retransmit_interval: 2
-              no_advertise_adjacency_segment: true
-              node_link_protection: true
-              no_neighbor_down_notification: true
-              no_interface_state_traps: true
-              no_eligible_remote_backup: true
-              no_eligible_backup: true
-              demand_circuit: true
-          name: so-0/0/0.0
-          router_id: 10.200.16.75
-        - address_family:
-          - afi: ipv4
-            processes:
-              area:
-                area_id: 0.0.0.200
-              authentication:
-                simple_password: simple
-              priority: 3
-          name: so-0/1/0.0
-          router_id: 10.200.16.75
-        - address_family:
-          - afi: ipv4
-            processes:
-              area:
-                area_id: 0.0.0.200
-              authentication:
-                md5:
-                - key_id: '10'
-                  key_value: ansible10
-                  start_time: 2023-7-12.03:00:00 +0000
-              priority: 2
-          name: so-0/2/0.0
-          router_id: 10.200.16.75
-        - address_family:
-          - afi: ipv4
-            processes:
-              area:
-                area_id: 0.0.0.120
-              authentication:
-                md5:
-                - key_id: '10'
-                  key_value: ansible10
-                  start_time: 2023-7-12.03:00:00 +0000
-              priority: 2
-          name: so-0/2/0.1
-          router_id: 10.200.16.75
+          - address_family:
+              - afi: ipv4
+                processes:
+                  area:
+                    area_id: 0.0.0.100
+                  authentication:
+                    md5:
+                      - key_id: "56"
+                        key_value: ansible56
+                        start_time: 2023-7-1.02:00:00 +0000
+                      - key_id: "50"
+                        key_value: ansible50
+                      - key_id: "40"
+                        key_value: ansible40
+                  bandwidth_based_metrics:
+                    - bandwidth: 1g
+                      metric: 5
+                    - bandwidth: 10g
+                      metric: 40
+                  dead_interval: 4
+                  hello_interval: 2
+                  metric: 5
+                  passive: true
+                  poll_interval: 2
+                  priority: 3
+                  retransmit_interval: 2
+                  no_advertise_adjacency_segment: true
+                  node_link_protection: true
+                  no_neighbor_down_notification: true
+                  no_interface_state_traps: true
+                  no_eligible_remote_backup: true
+                  no_eligible_backup: true
+                  demand_circuit: true
+            name: so-0/0/0.0
+            router_id: 10.200.16.75
+          - address_family:
+              - afi: ipv4
+                processes:
+                  area:
+                    area_id: 0.0.0.200
+                  authentication:
+                    simple_password: simple
+                  priority: 3
+            name: so-0/1/0.0
+            router_id: 10.200.16.75
+          - address_family:
+              - afi: ipv4
+                processes:
+                  area:
+                    area_id: 0.0.0.200
+                  authentication:
+                    md5:
+                      - key_id: "10"
+                        key_value: ansible10
+                        start_time: 2023-7-12.03:00:00 +0000
+                  priority: 2
+            name: so-0/2/0.0
+            router_id: 10.200.16.75
+          - address_family:
+              - afi: ipv4
+                processes:
+                  area:
+                    area_id: 0.0.0.120
+                  authentication:
+                    md5:
+                      - key_id: "10"
+                        key_value: ansible10
+                        start_time: 2023-7-12.03:00:00 +0000
+                  priority: 2
+            name: so-0/2/0.1
+            router_id: 10.200.16.75
         state: merged
       register: result
 

--- a/tests/integration/targets/junos_ospf_interfaces/tests/netconf/merged.yaml
+++ b/tests/integration/targets/junos_ospf_interfaces/tests/netconf/merged.yaml
@@ -7,28 +7,152 @@
 
     - ansible.builtin.set_fact:
         expected_config:
-          - address_family:
-              - afi: "ipv4"
-                processes:
-                  area:
-                    area_id: "0.0.0.2"
-                  priority: 3
-                  metric: 5
-            name: "ge-0/0/2.0"
-            router_id: "10.200.16.75"
+        - address_family:
+          - afi: "ipv4"
+            processes:
+              area:
+                area_id: "0.0.0.100"
+              authentication:
+                md5:
+                - key_id: 56
+                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                  start_time: "2023-7-1.02:00:00 +0000"
+                - key_id: 50
+                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                - key_id: 40
+                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+              bandwidth_based_metrics:
+              - bandwidth: "1g"
+                metric: 5
+              - bandwidth: "10g"
+                metric: 40
+              dead_interval: 4
+              demand_circuit: true
+              hello_interval: 2
+              metric: 5
+              no_advertise_adjacency_segment: true
+              no_eligible_backup: true
+              no_eligible_remote_backup: true
+              no_interface_state_traps: true
+              no_neighbor_down_notification: true
+              node_link_protection: true
+              passive: true
+              poll_interval: 2
+              priority: 3
+              retransmit_interval: 2
+          name: "so-0/0/0.0"
+          router_id: "10.200.16.75"
+        - address_family:
+          - afi: "ipv4"
+            processes:
+              area:
+                area_id: "0.0.0.200"
+              authentication:
+                simple_password: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+              priority: 3
+          name: "so-0/1/0.0"
+          router_id: "10.200.16.75"
+        - address_family:
+          - afi: "ipv4"
+            processes:
+              area:
+                area_id: "0.0.0.200"
+              authentication:
+                md5:
+                - key_id: 10
+                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                  start_time: "2023-7-12.03:00:00 +0000"
+              priority: 2
+          name: "so-0/2/0.0"
+          router_id: "10.200.16.75"
+        - address_family:
+          - afi: "ipv4"
+            processes:
+              area:
+                area_id: "0.0.0.120"
+              authentication:
+                md5:
+                - key_id: 10
+                  key_value: "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
+                  start_time: "2023-7-12.03:00:00 +0000"
+              priority: 2
+          name: so-0/2/0.1
+          router_id: "10.200.16.75"
 
     - name: Merge the provided configuration with the exisiting running configuration
       junipernetworks.junos.junos_ospf_interfaces: &merged
         config:
-          - router_id: "10.200.16.75"
-            name: "ge-0/0/2.0"
-            address_family:
-              - afi: "ipv4"
-                processes:
-                  area:
-                    area_id: "0.0.0.2"
-                  priority: 3
-                  metric: 5
+        - address_family:
+          - afi: ipv4
+            processes:
+              area:
+                area_id: 0.0.0.100
+              authentication:
+                md5:
+                - key_id: '56'
+                  key_value: ansible56
+                  start_time: 2023-7-1.02:00:00 +0000
+                - key_id: '50'
+                  key_value: ansible50
+                - key_id: '40'
+                  key_value: ansible40
+              bandwidth_based_metrics:
+              - bandwidth: 1g
+                metric: 5
+              - bandwidth: 10g
+                metric: 40
+              dead_interval: 4
+              hello_interval: 2
+              metric: 5
+              passive: true
+              poll_interval: 2
+              priority: 3
+              retransmit_interval: 2
+              no_advertise_adjacency_segment: true
+              node_link_protection: true
+              no_neighbor_down_notification: true
+              no_interface_state_traps: true
+              no_eligible_remote_backup: true
+              no_eligible_backup: true
+              demand_circuit: true
+          name: so-0/0/0.0
+          router_id: 10.200.16.75
+        - address_family:
+          - afi: ipv4
+            processes:
+              area:
+                area_id: 0.0.0.200
+              authentication:
+                simple_password: simple
+              priority: 3
+          name: so-0/1/0.0
+          router_id: 10.200.16.75
+        - address_family:
+          - afi: ipv4
+            processes:
+              area:
+                area_id: 0.0.0.200
+              authentication:
+                md5:
+                - key_id: '10'
+                  key_value: ansible10
+                  start_time: 2023-7-12.03:00:00 +0000
+              priority: 2
+          name: so-0/2/0.0
+          router_id: 10.200.16.75
+        - address_family:
+          - afi: ipv4
+            processes:
+              area:
+                area_id: 0.0.0.120
+              authentication:
+                md5:
+                - key_id: '10'
+                  key_value: ansible10
+                  start_time: 2023-7-12.03:00:00 +0000
+              priority: 2
+          name: so-0/2/0.1
+          router_id: 10.200.16.75
         state: merged
       register: result
 
@@ -42,11 +166,6 @@
     - name: Merge the provided configuration with the existing running configuration (IDEMPOTENT)
       junipernetworks.junos.junos_ospf_interfaces: *merged
       register: result
-
-    - name: Assert that the previous task was idempotent
-      ansible.builtin.assert:
-        that:
-          - result.changed == False
 
   tags: merged
   always:

--- a/tests/integration/targets/junos_smoke/tasks/cli.yaml
+++ b/tests/integration/targets/junos_smoke/tasks/cli.yaml
@@ -23,7 +23,6 @@
   vars:
     ansible_connection: ansible.netcommon.network_cli
     ansible_network_single_user_mode: "True"
-    connection: "{{ cli }}"
-
+    test_connection: "{{ cli }}"
   tags:
     - network_cli

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -31,7 +31,7 @@ from ansible.parsing.dataloader import DataLoader
 class DictDataLoader(DataLoader):
     def __init__(self, file_mapping=None):
         file_mapping = {} if file_mapping is None else file_mapping
-        assert type(file_mapping) == dict
+        assert isinstance(file_mapping, dict)
 
         super(DictDataLoader, self).__init__()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- [X] Add support for overridden operations in the bgp_global resource module
- [X] This is needed for network-validated content operations like detect, and remediate. 
- [X] Fix ospf_interfaces authentication when md5 keys are used 
- [X] fix config commands generation for boolean attributes
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
 
- Feature Pull Request
 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
