### PR TITLE
Fix junos gather facts issue with integration tests

### DIFF
--- a/tests/integration/targets/prepare_junos_tests/tasks/main.yml
+++ b/tests/integration/targets/prepare_junos_tests/tasks/main.yml
@@ -1,18 +1,4 @@
 ---
-- name: Debug task
-  ansible.builtin.debug:
-    msg: "START prepare_junos_tests/main.yaml"
-
-- name: Ensure netconf is enabled
-  connection: ansible.netcommon.network_cli
-  tags: netconf
-  junipernetworks.junos.junos_netconf:
-    state: present
-
-- name: Wait for netconf server to come up
-  delegate_to: localhost
-  tags: netconf
-  ansible.builtin.wait_for:
-    host: "{{ hostvars[item].ansible_host }}"
-    port: 830
-  with_inventory_hostnames: junos
+- name: Run the prepare steps if requested
+  ansible.builtin.include_tasks: prepare.yml
+  when: prepare_junos_tests_task | default(True) | bool

--- a/tests/integration/targets/prepare_junos_tests/tasks/prepare.yml
+++ b/tests/integration/targets/prepare_junos_tests/tasks/prepare.yml
@@ -1,0 +1,18 @@
+---
+- name: Debug task
+  ansible.builtin.debug:
+    msg: "START prepare_junos_tests/main.yaml"
+
+- name: Ensure netconf is enabled
+  connection: ansible.netcommon.network_cli
+  tags: netconf
+  junipernetworks.junos.junos_netconf:
+    state: present
+
+- name: Wait for netconf server to come up
+  delegate_to: localhost
+  tags: netconf
+  ansible.builtin.wait_for:
+    host: "{{ hostvars[item].ansible_host }}"
+    port: 830
+  with_inventory_hostnames: junos


### PR DESCRIPTION
##### SUMMARY
Fixes the error: `failed to execute: junipernetworks.junos.junos_facts` when gather_facts: yes 

##### ISSUE TYPE
- Bugfix Pull Request
