### PR TITLE
return Empty resource facts data when no config found

### DIFF
--- a/changelogs/fragments/empty_facts.yaml
+++ b/changelogs/fragments/empty_facts.yaml
@@ -1,0 +1,20 @@
+---
+bugfixes:
+  - initialize facts dictionary with empty containers for respective resources mentioned below
+  - acls
+  - lldp_global
+  - lldp_interfaces
+  - logging_global
+  - ntp_global
+  - ospf_interfaces
+  - ospfv2
+  - ospfv3
+  - prefix_lists
+  - routing_instances
+  - routing_options
+  - security_policies
+  - security_policies_global
+  - security_zones
+  - snmp_server
+  - static_routes
+  - vlans

--- a/plugins/module_utils/network/junos/facts/acls/acls.py
+++ b/plugins/module_utils/network/junos/facts/acls/acls.py
@@ -85,7 +85,7 @@ class AclsFacts(object):
 
         objs = []
         for resource in resources:
-            if resource:
+            if resource is not None:
                 xml = self._get_xml_dict(resource)
                 for family, sub_dict in xml["firewall"]["family"].items():
                     sub_dict["family"] = family

--- a/plugins/module_utils/network/junos/facts/lldp_global/lldp_global.py
+++ b/plugins/module_utils/network/junos/facts/lldp_global/lldp_global.py
@@ -80,7 +80,7 @@ class Lldp_globalFacts(object):
                 to_bytes(data, errors="surrogate_then_replace"),
             )
 
-        facts = {}
+        facts = {"lldp_global": {}}
         config = deepcopy(self.generated_spec)
         resources = data.xpath("configuration/protocols/lldp")
         if resources:

--- a/plugins/module_utils/network/junos/facts/lldp_interfaces/lldp_interfaces.py
+++ b/plugins/module_utils/network/junos/facts/lldp_interfaces/lldp_interfaces.py
@@ -87,7 +87,7 @@ class Lldp_interfacesFacts(object):
                 obj = self.render_config(self.generated_spec, resource)
                 if obj:
                     objs.append(obj)
-        facts = {}
+        facts = {"lldp_interfaces": []}
         if objs:
             facts["lldp_interfaces"] = []
             params = utils.validate_config(

--- a/plugins/module_utils/network/junos/facts/logging_global/logging_global.py
+++ b/plugins/module_utils/network/junos/facts/logging_global/logging_global.py
@@ -99,7 +99,7 @@ class Logging_globalFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"logging_global": {}}
         if objs:
             facts["logging_global"] = {}
             params = utils.validate_config(

--- a/plugins/module_utils/network/junos/facts/ntp_global/ntp_global.py
+++ b/plugins/module_utils/network/junos/facts/ntp_global/ntp_global.py
@@ -99,9 +99,8 @@ class Ntp_globalFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"ntp_global": {}}
         if objs:
-            facts["ntp_global"] = {}
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/facts/ospf_interfaces/ospf_interfaces.py
@@ -116,9 +116,9 @@ class Ospf_interfacesFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"ospf_interfaces": []}
         if objs:
-            facts["junos_ospf_interfaces"] = []
+            facts["ospf_interfaces"] = []
             params = _validate_config(
                 self._module,
                 self.argument_spec,
@@ -127,7 +127,7 @@ class Ospf_interfacesFacts(object):
             )
 
             for cfg in params["config"]:
-                facts["junos_ospf_interfaces"].append(remove_empties(cfg))
+                facts["ospf_interfaces"].append(remove_empties(cfg))
 
         ansible_facts["ansible_network_resources"].update(facts)
         return ansible_facts

--- a/plugins/module_utils/network/junos/facts/ospfv2/ospfv2.py
+++ b/plugins/module_utils/network/junos/facts/ospfv2/ospfv2.py
@@ -122,9 +122,8 @@ class Ospfv2Facts(object):
                 if obj:
                     objs.append(obj)
 
-        facts = {}
+        facts = {"ospfv2": []}
         if objs is not None:
-            facts["ospfv2"] = []
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/ospfv3/ospfv3.py
+++ b/plugins/module_utils/network/junos/facts/ospfv3/ospfv3.py
@@ -123,9 +123,8 @@ class Ospfv3Facts(object):
                 if obj:
                     objs.append(obj)
 
-        facts = {}
+        facts = {"ospfv3": []}
         if objs:
-            facts["ospfv3"] = []
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/prefix_lists/prefix_lists.py
+++ b/plugins/module_utils/network/junos/facts/prefix_lists/prefix_lists.py
@@ -101,9 +101,8 @@ class Prefix_listsFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"prefix_lists": []}
         if objs:
-            facts["prefix_lists"] = []
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/routing_instances/routing_instances.py
+++ b/plugins/module_utils/network/junos/facts/routing_instances/routing_instances.py
@@ -97,9 +97,8 @@ class Routing_instancesFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"routing_instances": []}
         if objs:
-            facts["routing_instances"] = []
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/routing_options/routing_options.py
+++ b/plugins/module_utils/network/junos/facts/routing_options/routing_options.py
@@ -97,9 +97,8 @@ class Routing_optionsFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"routing_options": []}
         if objs:
-            facts["routing_options"] = {}
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/security_policies/security_policies.py
+++ b/plugins/module_utils/network/junos/facts/security_policies/security_policies.py
@@ -109,9 +109,8 @@ class Security_policiesFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"security_policies": {}}
         if objs:
-            facts["security_policies"] = {}
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/security_policies_global/security_policies_global.py
+++ b/plugins/module_utils/network/junos/facts/security_policies_global/security_policies_global.py
@@ -109,9 +109,8 @@ class Security_policies_globalFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"security_policies_global": {}}
         if objs:
-            facts["security_policies_global"] = {}
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/security_zones/security_zones.py
+++ b/plugins/module_utils/network/junos/facts/security_zones/security_zones.py
@@ -109,9 +109,8 @@ class Security_zonesFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"security_zones": {}}
         if objs:
-            facts["security_zones"] = {}
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/snmp_server/snmp_server.py
+++ b/plugins/module_utils/network/junos/facts/snmp_server/snmp_server.py
@@ -97,9 +97,8 @@ class Snmp_serverFacts(object):
                 xml = self._get_xml_dict(resource)
                 objs = self.render_config(self.generated_spec, xml)
 
-        facts = {}
+        facts = {"snmp_server": {}}
         if objs:
-            facts["snmp_server"] = {}
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/junos/facts/static_routes/static_routes.py
@@ -95,7 +95,7 @@ class Static_routesFacts(object):
                 if obj:
                     objs.append(obj)
 
-        facts = {'static_routes': []}
+        facts = {"static_routes": []}
         if objs:
             params = utils.validate_config(
                 self.argument_spec,

--- a/plugins/module_utils/network/junos/facts/static_routes/static_routes.py
+++ b/plugins/module_utils/network/junos/facts/static_routes/static_routes.py
@@ -95,9 +95,8 @@ class Static_routesFacts(object):
                 if obj:
                     objs.append(obj)
 
-        facts = {}
+        facts = {'static_routes': []}
         if objs:
-            facts["static_routes"] = []
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/plugins/module_utils/network/junos/facts/vlans/vlans.py
+++ b/plugins/module_utils/network/junos/facts/vlans/vlans.py
@@ -94,9 +94,8 @@ class VlansFacts(object):
                 obj = self.render_config(self.generated_spec, resource)
                 if obj:
                     objs.append(obj)
-        facts = {}
+        facts = {"vlans": []}
         if objs:
-            facts["vlans"] = []
             params = utils.validate_config(
                 self.argument_spec,
                 {"config": objs},

--- a/tests/integration/targets/junos_facts/tests/netconf/network_facts.yaml
+++ b/tests/integration/targets/junos_facts/tests/netconf/network_facts.yaml
@@ -1,0 +1,56 @@
+---
+- ansible.builtin.debug:
+    msg="START cli_config/cli_basic.yaml on connection={{ ansible_connection
+    }}"
+
+- name: Gather junipernetworks junos facts
+  junipernetworks.junos.junos_facts:
+    gather_subset: config
+    gather_network_resources:
+      - acls
+      - lldp_global
+      - lldp_interfaces
+      - logging_global
+      - ntp_global
+      - ospf_interfaces
+      - ospfv2
+      - ospfv3
+      - prefix_lists
+      - routing_instances
+      - routing_options
+      - security_policies
+      - security_policies_global
+      - security_zones
+      - snmp_server
+      - static_routes
+      - vlans
+  register: find_the_routes
+
+- name: Display Facts
+  ansible.builtin.debug:
+    msg: "{{ find_the_routes }}"
+
+- name: Assert that empty facts was generated
+  ansible.builtin.assert:
+    that:
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['acls'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['lldp_global'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['lldp_interfaces'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['logging_global'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['ntp_global'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['ospf_interfaces'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['ospfv2'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['ospfv3'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['prefix_lists'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['routing_instances'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['routing_options'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['security_policies'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['security_policies_global'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['security_zones'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['snmp_server'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['static_routes'] == []"
+      - " find_the_routes['ansible_facts']['ansible_network_resources']['vlans'] == []"
+
+- ansible.builtin.debug:
+    msg="END cli_config/cli_basic.yaml on connection={{ ansible_connection
+    }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We need to return with empty facts when no config found for respective resources.
ref: https://github.com/network-automation/toolkit/issues/47
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
