### PR TITLE
"delete" lines which only delete candidate config shouldn't be ignored

### DIFF
--- a/changelogs/fragments/config_delete_filter.yaml
+++ b/changelogs/fragments/config_delete_filter.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - In junos_config, "delete" lines which only delete candidate config lines are no longer ignored.


### PR DESCRIPTION
##### SUMMARY
The `filter_delete_statements()` function is intended to remove `delete` statements which doesn't delete anything in the running config. If there aren't any matching `set` statements in the running config, the `delete` statement is deleted. However it doesn't take the previous statements from the candidate config into consideration.

This change walks through all statements above each `delete` statement of the candidate config and removes them if they match.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junos_config

##### ADDITIONAL INFORMATION
Config task:
```
- name: Apply router config.
  junipernetworks.junos.junos_config:
    lines:
      - set groups ANSIBLETEST interfaces irb unit 102 description "bar"
      - delete groups ANSIBLETEST interfaces irb unit 102 description
```

Output before change:
```
TASK [../roles/net_routerconfig : Apply router config.] *****************************************************
[edit groups ANSIBLETEST interfaces irb]
+     unit 102 {
+         description bar;
+     }
changed: [router1]
```

Output after change:
```
TASK [../roles/net_routerconfig : Apply router config.] *****************************************************
ok: [router1]
```