### PR TITLE
junos_user: delete user role validation

### DIFF
--- a/plugins/modules/junos_user.py
+++ b/plugins/modules/junos_user.py
@@ -227,7 +227,6 @@ try:
 except ImportError:
     from xml.etree.ElementTree import Element, SubElement
 
-ROLES = ["operator", "read-only", "super-user", "unauthorized"]
 USE_PERSISTENT_CONNECTION = True
 
 
@@ -384,7 +383,7 @@ def main():
     element_spec = dict(
         name=dict(),
         full_name=dict(),
-        role=dict(choices=ROLES),
+        role=dict(),
         encrypted_password=dict(no_log=True),
         sshkey=dict(no_log=False),
         state=dict(choices=["present", "absent"], default="present"),


### PR DESCRIPTION
##### SUMMARY
"Fixes #536" disable validation for user "class/role" field

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
junipernetworks.junos.junos_user

##### ADDITIONAL INFORMATION
If role/class name not valid we receive error message from Juniper system, not from module code. 