### PR TITLE
Update ospf_interfaces.py

### DIFF
--- a/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
@@ -292,7 +292,9 @@ class Ospf_interfaces(ConfigBase):
                         existing_config = have[0]
                         if existing_config["name"] == ospf_interfaces["name"]:
                             intf_node.attrib.update(delete)
-
+                if "interface_type" in processes:
+                    iface_type = processes.get("interface_type")
+                    build_child_xml_node(intf_node, "interface-type", iface_type)
                 if "authentication" in processes:
                     auth = processes.get("authentication")
                     auth_node = build_child_xml_node(intf_node, "authentication")


### PR DESCRIPTION
Fixes issue #558, addition will include the interface type in the netconf XML render.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The module was ignoring the interface_type parameter. This adds it. I used the `if "authentication" in proccesses` block as a reference. I used  processes.get() to get the parameters, and build_child_xml_node to build the XML

Fixes #558

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

junipernetworks.junos.junos_ospf_interfaces

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
Before: 

Running this: 
```yaml
    - name: Configure OSPF (part 2)
      junipernetworks.junos.junos_ospf_interfaces:
        config:
          - name: 'ge-0/0/0.0'
            address_family:
              - afi: 'ipv4'
                processes:
                  area:
                    area_id: '0.0.0.0'
                  interface_type: p2p
        state: rendered
      register: rendered_output
    - name: Print rendered output
      ansible.builtin.debug:
        msg: "{{ rendered_output }}"
```
Would render this: 

```xml
<nc:protocols xmlns:nc= \"urn:ietf:params:xml:ns:netconf:base:1.0\">
    <nc:ospf>
        <nc:area>
            <nc:name>0.0.0.0</nc:name>
            <nc:interface>
                <nc:name>ge-0/0/0.0</nc:name>
            </nc:interface>
        </nc:area>
    </nc:ospf>
</nc:protocols>
```

After (same playbook)

```xml
<nc:protocols xmlns:nc= \"urn:ietf:params:xml:ns:netconf:base:1.0\">
    <nc:ospf>
        <nc:area>
            <nc:name>0.0.0.0</nc:name>
            <nc:interface>
                <nc:name>ge-0/0/0.0</nc:name>
                <nc:inteface-type>p2p</nc:inteface-type>
            </nc:interface>
        </nc:area>
    </nc:ospf>
</nc:protocols>
```

Tested on Junos 24.4R1.9

