### PR TITLE
Fixes #558 along with unit test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 
 repos:
   - repo: https://github.com/ansible-network/collection_prep
-    rev: 1.1.1
+    rev: 1.1.2
     hooks:
       - id: update-docs
 
@@ -51,6 +51,6 @@ repos:
       - id: black
 
   - repo: https://github.com/pycqa/flake8
-    rev: 7.2.0
+    rev: 7.3.0
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: add-trailing-comma
 

--- a/README.md
+++ b/README.md
@@ -34,10 +34,8 @@ For more information about communication, see the [Ansible communication guide](
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.16.0**.
+This collection has been tested against the following Ansible versions: **>=2.16.0**.
 
-For collections that support Ansible 2.9, please ensure you update your `network_os` to use the
-fully qualified collection name (for example, `cisco.ios.ios`).
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
 PEP440 is the schema used to describe the versions of Ansible.

--- a/changelogs/fragments/fix_sanity.yaml
+++ b/changelogs/fragments/fix_sanity.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Add ignore-2.20.txt

--- a/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
+++ b/plugins/module_utils/network/junos/config/ospf_interfaces/ospf_interfaces.py
@@ -292,7 +292,9 @@ class Ospf_interfaces(ConfigBase):
                         existing_config = have[0]
                         if existing_config["name"] == ospf_interfaces["name"]:
                             intf_node.attrib.update(delete)
-
+                if "interface_type" in processes:
+                    iface_type = processes.get("interface_type")
+                    build_child_xml_node(intf_node, "interface-type", iface_type)
                 if "authentication" in processes:
                     auth = processes.get("authentication")
                     auth_node = build_child_xml_node(intf_node, "authentication")

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,1 @@
+plugins/action/junos.py action-plugin-docs # base class for deprecated network platform modules using `connection: local`

--- a/tests/unit/modules/network/junos/test_junos_ospf_interfaces.py
+++ b/tests/unit/modules/network/junos/test_junos_ospf_interfaces.py
@@ -111,6 +111,7 @@ class TestJunosOspfv3Module(TestJunosModule):
                                     area=dict(area_id="0.0.0.2"),
                                     priority=3,
                                     metric=5,
+                                    interface_type="p2p"
                                 ),
                             ),
                         ],
@@ -121,7 +122,7 @@ class TestJunosOspfv3Module(TestJunosModule):
         )
         commands = [
             '<nc:protocols xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0"><nc:ospf>'
-            "<nc:area><nc:name>0.0.0.2</nc:name><nc:interface><nc:name>ge-0/0/2.0</nc:name>"
+            "<nc:area><nc:name>0.0.0.2</nc:name><nc:interface><nc:name>ge-0/0/2.0</nc:name><nc:interface-type>p2p</nc:interface-type>"
             "<nc:priority>3</nc:priority><nc:metric>5</nc:metric></nc:interface></nc:area></nc:ospf></nc:protocols>",
             '<nc:routing-options xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0">'
             "<nc:router-id>10.200.16.75</nc:router-id></nc:routing-options>",


### PR DESCRIPTION

Adds the missing unit test on top of the PR #559, rest of the description is from the original PR. 

Fixes issue https://github.com/ansible-collections/junipernetworks.junos/issues/558, addition will include the interface type in the netconf XML render.


##### SUMMARY
The module was ignoring the interface_type parameter. This adds it. I used the if "authentication" in proccesses block as a reference. I used processes.get() to get the parameters, and build_child_xml_node to build the XML

Fixes https://github.com/ansible-collections/junipernetworks.junos/issues/558

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

junipernetworks.junos.junos_ospf_interfaces

##### ADDITIONAL INFORMATION
Before: 

Running this: 
```yaml
    - name: Configure OSPF (part 2)
      junipernetworks.junos.junos_ospf_interfaces:
        config:
          - name: 'ge-0/0/0.0'
            address_family:
              - afi: 'ipv4'
                processes:
                  area:
                    area_id: '0.0.0.0'
                  interface_type: p2p
        state: rendered
      register: rendered_output
    - name: Print rendered output
      ansible.builtin.debug:
        msg: "{{ rendered_output }}"
```

Would render this:

```
<nc:protocols xmlns:nc= \"urn:ietf:params:xml:ns:netconf:base:1.0\">
    <nc:ospf>
        <nc:area>
            <nc:name>0.0.0.0</nc:name>
            <nc:interface>
                <nc:name>ge-0/0/0.0</nc:name>
            </nc:interface>
        </nc:area>
    </nc:ospf>
</nc:protocols>

```
After (same playbook)

```
<nc:protocols xmlns:nc= \"urn:ietf:params:xml:ns:netconf:base:1.0\">
    <nc:ospf>
        <nc:area>
            <nc:name>0.0.0.0</nc:name>
            <nc:interface>
                <nc:name>ge-0/0/0.0</nc:name>
                <nc:inteface-type>p2p</nc:inteface-type>
            </nc:interface>
        </nc:area>
    </nc:ospf>
</nc:protocols>
```

Tested on Junos 24.4R1.9