### PR TITLE
removed python3 and python3-devel from bindep file

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -2,6 +2,4 @@
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
 gcc-c++ [doc test platform:rpm]
-python3-devel [test platform:rpm]
-python3 [test platform:rpm]
 libssh-devel [compile platform:rpm]


### PR DESCRIPTION
With AAP 2.5+ ee-minimal-rhel9:latest these bindep entries tries to install an extra Python RPM during EE builds, which overrides the base image Python and causes Portal EE builds to fail.

so we need to remove python3 / python3-devel from bindep.txt

https://redhat-internal.slack.com/archives/C9W5WCSMS/p1763558738561779