### PR TITLE
junos_acls: fix protocol handling for inet6 filters

### DIFF
--- a/plugins/module_utils/network/junos/config/acls/acls.py
+++ b/plugins/module_utils/network/junos/config/acls/acls.py
@@ -312,11 +312,18 @@ class Acls(ConfigBase):
                                             ports,
                                         )
                         if ace.get("protocol"):
-                            build_child_xml_node(
-                                from_node,
-                                "protocol",
-                                ace["protocol"],
-                            )
+                            if family == "inet":
+                                build_child_xml_node(
+                                    from_node,
+                                    "protocol",
+                                    ace["protocol"],
+                                )
+                            elif family == "inet6":
+                                build_child_xml_node(
+                                    from_node,
+                                    "next-header",
+                                    ace["protocol"],
+                                )
                         if ace.get("protocol_options"):
                             if ace["protocol_options"].get("icmp"):
                                 icmp_code = build_child_xml_node(


### PR DESCRIPTION
##### SUMMARY
The junos_acls module always sets "protocol" in aces.
For inet6 filters, Junos requires "next-header" instead of "protocol", and using "protocol" results in a configuration error.

This change selects "protocol" for inet filters and "next-header" for inet6 filters based on the AFI.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
junos_acls