### PR TITLE
Upload Upstream Tests to common dashboard

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,15 +49,35 @@ jobs:
         git+https://github.com/ansible-collections/ansible.utils.git
         git+https://github.com/ansible-collections/ansible.netcommon.git
 
-  all_green:
-    if: ${{ always() && (github.event_name != 'schedule') }}
+  report-status:
+    if: ${{ always() && github.event_name == 'schedule' }}
     needs:
       - changelog
       - build-import
       - sanity
       - unit-galaxy
       - ansible-lint
+      - unit-source
+    uses: ansible/ansible-content-actions/.github/workflows/upload_upstream_results.yaml@main
+    with:
+      job_context: ${{ toJSON(needs) }}
+      component_name: ${{ github.event.repository.name }}
+      UPLOAD_USER: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_USER }}
+      UPLOAD_URL: ${{ vars.PDE_ORG_RESULTS_AGGREGATOR_UPLOAD_URL }}
+    secrets:
+      UPLOAD_PASSWORD: ${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}
+
+  all_green:
+    if: ${{ always() }}
+    needs:
+      - changelog
+      - build-import
+      - sanity
+      - unit-galaxy
+      - ansible-lint
+      - unit-source
       - sonar
+      - report-status
     runs-on: ubuntu-latest
     steps:
       - run: >-
@@ -69,5 +89,6 @@ jobs:
           '${{ needs.unit-galaxy.result }}',
           '${{ needs.ansible-lint.result }}',
           '${{ needs.unit-source.result }}',
-          '${{ needs.sonar.result }}'
+          '${{ needs.sonar.result }}',
+          '${{ needs.report-status.result }}'
           ])"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,14 +68,13 @@ jobs:
       UPLOAD_PASSWORD: ${{ secrets.PDE_ORG_RESULTS_UPLOAD_PASSWORD }}
 
   all_green:
-    if: ${{ always() }}
+    if: ${{ always() && (github.event_name != 'schedule') }}
     needs:
       - changelog
       - build-import
       - sanity
       - unit-galaxy
       - ansible-lint
-      - unit-source
       - sonar
       - report-status
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- What is being changed?
The tests.yml workflow is updated to aggregate all upstream test results (sanity, lint, unit) into a JUnit XML report and upload it to the dashboard.
- Why is this change needed?
To increase visibility and monitoring of Ansible components.
- How does this change address the issue?
It implements a report-status job which eventually uses a reusable function to upload the metrics to dashboard via API call.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
